### PR TITLE
feat: add Ruff configuration for Python linting and formatting

### DIFF
--- a/.config/ruff.toml
+++ b/.config/ruff.toml
@@ -8,7 +8,7 @@ exclude = [
 
 line-length   = 88
 indent-width  = 4
-target-version = "py312"
+target-version = ["py312"]
 
 [lint]
 select       = ["ALL"]

--- a/.config/ruff.toml
+++ b/.config/ruff.toml
@@ -1,0 +1,25 @@
+exclude = [
+  ".git",
+  "node_modules",
+  "venv",
+  ".config",
+  ".github",
+]
+
+line-length   = 88
+indent-width  = 4
+target-version = "py312"
+
+[lint]
+select       = ["ALL"]
+ignore       = [
+  "D100",
+  "INP001",
+]
+fixable      = ["ALL"]
+
+[format]
+quote-style               = "double"   # Use double quotes like Black
+indent-style              = "space"    # Indent with spaces
+skip-magic-trailing-comma = false      # Respect trailing commas
+line-ending               = "auto"     # Detect platform line endings

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -49,6 +49,10 @@
       "version": "latest"
     },
 
+    // ruff (Python linter and formatter)
+    // https://github.com/devcontainers-extra/features/tree/main/src/ruff
+    "ghcr.io/devcontainers-extra/features/ruff:1": {},
+
     // shellCheck
     // https://github.com/lukewiwa/features/tree/main/src/shellcheck
     "ghcr.io/lukewiwa/features/shellcheck:0": {
@@ -128,8 +132,10 @@
 
         // Editor
         // - .editorconfig support
-        "EditorConfig.EditorConfig"
+        "EditorConfig.EditorConfig",
 
+        // Ruff (Python linter)
+        "charliermarsh.ruff"
         ////////////////////////////////////////////////////////////////////////
         // Excluded extensions
         ////////////////////////////////////////////////////////////////////////
@@ -238,6 +244,18 @@
           "${containerWorkspaceFolder}/.config/.hadolint.yml",
           "--no-color"
         ],
+
+        "python.linting.enabled": false,
+        "python.linting.flake8Enabled": false,
+        "python.linting.pylintEnabled": false,
+
+        // Ruff
+        "ruff.enable": true,
+        "ruff.configuration": "${containerWorkspaceFolder}/.config/ruff.toml",
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.formatOnSave": false
+        },
 
         // yamllint
         // - Use installed yamllint

--- a/package.json
+++ b/package.json
@@ -2,11 +2,14 @@
   "name": "project-zomboid-server",
   "type": "module",
   "scripts": {
-    "lint": "eslint --config ./.config/.eslint.config.mjs .",
-    "lint-fix": "eslint --config ./.config/.eslint.config.mjs --fix .",
+    "lint": "eslint --config ./.config/.eslint.config.mjs --quiet .",
+    "lint-fix": "eslint --config ./.config/.eslint.config.mjs --fix --quiet .",
+    "ruff": "ruff check --config ./.config/ruff.toml --quiet .",
+    "ruff-fix": "ruff check --config ./.config/ruff.toml --fix --quiet .",
     "format": "prettier --config ./.config/.prettierrc.yml --ignore-path ./.config/.prettierignore --write .",
-    "ci:eslint": "eslint --config ./.config/.eslint.config.mjs --max-warnings 0 --no-color .",
-    "ci:prettier": "prettier --config ./.config/.prettierrc.yml --ignore-path ./.config/.prettierignore --check --no-color ."
+    "ci:eslint": "eslint --config ./.config/.eslint.config.mjs --max-warnings 0 --no-color --quiet .",
+    "ci:prettier": "prettier --config ./.config/.prettierrc.yml --ignore-path ./.config/.prettierignore --check --no-color .",
+    "ci:ruff": "ruff check --config ./.config/ruff.toml --quiet ."
   },
   "devDependencies": {
     "eslint": "^9.20.0",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "project-zomboid-server",
   "type": "module",
   "scripts": {
-    "lint": "eslint --config ./.config/.eslint.config.mjs --quiet .",
-    "lint-fix": "eslint --config ./.config/.eslint.config.mjs --fix --quiet .",
+    "lint": "eslint --config ./.config/.eslint.config.mjs .",
+    "lint-fix": "eslint --config ./.config/.eslint.config.mjs --fix .",
     "ruff": "ruff check --config ./.config/ruff.toml --quiet .",
     "ruff-fix": "ruff check --config ./.config/ruff.toml --fix --quiet .",
     "format": "prettier --config ./.config/.prettierrc.yml --ignore-path ./.config/.prettierignore --write .",


### PR DESCRIPTION
This pull request introduces the integration of `ruff` as a Python linter and formatter into the development environment. It includes configuration updates, modifications to the development container setup, and enhancements to the project's scripts for linting and formatting.

### Integration of `ruff` as Python linter and formatter:

* [`.config/ruff.toml`](diffhunk://#diff-6639227aea5055f6a073cd889de0656f0aab3f2123535feafc506969aecdb3e0R1-R25): Added configuration for `ruff`, specifying excluded directories, line length, indentation style, target Python version, linting rules, and formatting preferences.

* `.devcontainer/devcontainer.json`: 
  - Added `ruff` feature to the development container setup.
  - Enabled `ruff` as the default Python formatter and disabled other Python linters (`flake8` and `pylint`). Configured `ruff` to use the `.config/ruff.toml` file for settings.
  - Included the `ruff` extension for Visual Studio Code in the list of installed extensions.

### Enhancements to project scripts:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R12): Updated linting and formatting scripts to include `ruff` commands (`ruff` and `ruff-fix`) for Python files. Added a `ci:ruff` script for continuous integration checks. Also made `eslint` commands quieter by adding the `--quiet` flag.