### PR TITLE
feat: add server server env variables load scripts

### DIFF
--- a/server/env/server-init-flags.sh
+++ b/server/env/server-init-flags.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Project Zomboid Server Argument Flags
+#
+# This script defines default environment variables for the Project Zomboid
+# dedicated server startup script (start-server.sh). These variables can
+# be overridden at runtime to customize server behavior when running in Docker
+# or other containerized environments.
+#
+# Usage:
+#   Source this file before running start-server.sh:
+#   source ./server-init-flags.sh
+#   ./start-server.sh
+#
+# Docker Usage:
+#   Override any variable using Docker's -e flag:
+#   docker run -e SERVER_NAME="MyServer" -e PORT="16262" <image>
+
+# Enable automatic export of all variables
+set -a
+
+# General server configuration
+SERVER_DIR="${SERVER_DIR:-/pzomboid-server}"
+PRESETS_DIR="${PRESETS_DIR:-${SERVER_DIR}/media/lua/shared/Sandbox}"
+ZOMBOID_APP_ID="${ZOMBOID_APP_ID:-380870}"
+SERVER_PRESET="${SERVER_PRESET:-}"
+
+# Java and memory settings
+MEMORY="${MEMORY:-2048m}"
+SOFTRESET="${SOFTRESET:-1}" # 0 = False, 1 = True
+
+# Server behavior flags
+SERVER_NAME="${SERVER_NAME:-project-zomboid-server}"
+COOP_SERVER="${COOP_SERVER:-0}" # 0 = False, 1 = True
+NO_STEAM="${NO_STEAM:-0}"       # 0 = False, 1 = True
+CACHE_DIR="${CACHE_DIR:-/root/Zomboid}"
+DEBUG="${DEBUG:-0}" # 0 = False, 1 = True
+ADMIN_USERNAME="${ADMIN_USERNAME:-admin}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-admin}"
+IP="${IP:-0.0.0.0}"
+PORT="${PORT:-16261}"
+STEAM_VAC="${STEAM_VAC:-0}" # 0 = False, 1 = True
+STEAM_PORT_1="${STEAM_PORT_1:-8766}"
+STEAM_PORT_2="${STEAM_PORT_2:-8767}"
+
+# Disable automatic export
+set +a

--- a/server/env/server-init-settings.sh
+++ b/server/env/server-init-settings.sh
@@ -1,0 +1,314 @@
+#!/bin/bash
+# Project Zomboid Server Configuration Settings
+#
+# This script defines default environment variables for Project Zomboid
+# server configuration settings that correspond to the <server-name>.ini file.
+# These variables control general server behavior, gameplay mechanics, PvP settings,
+# anti-cheat protection, and various multiplayer features.
+#
+# These environment variables can be overridden at runtime to customize
+# server configuration when running in Docker or other containerized environments.
+# Each variable uses the bash parameter expansion syntax ${VAR:-default} to
+# provide fallback values if not explicitly set.
+#
+# Usage:
+#   Source this file before generating server configuration:
+#   source ./server-init-settings.sh
+#
+# Docker Usage:
+#   Override any variable using Docker's -e flag:
+#   docker run -e PVP="false" -e MAX_PLAYERS="64" -e PUBLIC="true" <image>
+#
+# Configuration Categories:
+#   - Basic server settings (PVP, player limits, ports)
+#   - Chat and communication (global chat, voice settings)
+#   - Gameplay mechanics (spawn points, safety system, loot respawn)
+#   - Safehouse and faction management
+#   - Admin and moderation tools
+#   - Anti-cheat protection (24 different protection types)
+#   - Backup and maintenance settings
+#   - Steam integration and workshop support
+
+# Enable automatic export of all variables
+set -a
+
+# Players can hurt and kill other players
+PVP="${PVP:-true}"
+# Game time stops when there are no players online
+PAUSE_EMPTY="${PAUSE_EMPTY:-true}"
+# Toggles global chat on or off.
+GLOBAL_CHAT="${GLOBAL_CHAT:-true}"
+# Chat streams available to players
+CHAT_STREAMS="${CHAT_STREAMS:-"s,r,a,w,y,sh,f,all"}"
+# Clients may join without already having an account in the whitelist. If set to false, administrators must manually create username/password combos.
+OPEN="${OPEN:-true}"
+# The first welcome message visible in the chat panel. This will be displayed immediately after player login.
+SERVER_WELCOME_MESSAGE="${SERVER_WELCOME_MESSAGE:-"Welcome to Project Zomboid Multiplayer! <LINE> <LINE> To interact with the Chat panel: press Tab, T, or Enter. <LINE> <LINE> The Tab key will change the target stream of the message. <LINE> <LINE> Global Streams: /all <LINE> Local Streams: /say, /yell <LINE> Special Steams: /whisper, /safehouse, /faction. <LINE> <LINE> Press the Up arrow to cycle through your message history. Click the Gear icon to customize chat. <LINE> <LINE> Happy surviving!"}"
+# Add unknown usernames to the whitelist when players join. Clients will supply their own username/password on joining. (This is for Open=true servers)
+AUTO_CREATE_USER_IN_WHITE_LIST="${AUTO_CREATE_USER_IN_WHITE_LIST:-false}"
+# Display usernames above player's heads in-game.
+DISPLAY_USER_NAME="${DISPLAY_USER_NAME:-true}"
+# Display first & last name above player's heads.
+SHOW_FIRST_AND_LAST_NAME="${SHOW_FIRST_AND_LAST_NAME:-false}"
+# Force every new player to spawn at these set x,y,z world coordinates. (Ignored when 0,0,0)
+SPAWN_POINT="${SPAWN_POINT:-"0,0,0"}"
+# Players can enter and leave PVP on an individual basis. When SafetySystem=false, players are free to hurt each other at any time if PVP is enabled.
+SAFETY_SYSTEM="${SAFETY_SYSTEM:-true}"
+# Display a skull icon over the head of players who have entered PVP mode
+SHOW_SAFETY="${SHOW_SAFETY:-true}"
+# The time it takes for a player to enter and leave PVP mode
+SAFETY_TOGGLE_TIMER="${SAFETY_TOGGLE_TIMER:-2}"
+# The delay before a player can enter or leave PVP mode again, having recently done so
+SAFETY_COOLDOWN_TIMER="${SAFETY_COOLDOWN_TIMER:-3}"
+# Item types new players spawn with. Separate multiple item types with commas.
+SPAWN_ITEMS="${SPAWN_ITEMS:-}"
+# Default starting port for player data. If UDP, this is this one of two ports used.
+DEFAULT_PORT="${DEFAULT_PORT:-16261}"
+# UDP port for server communication
+UDP_PORT="${UDP_PORT:-16262}"
+# Reset ID determines if the server has undergone a soft-reset. If this number does match the client, the client must create a new character.
+RESET_ID="${RESET_ID:-8267201}"
+# Enter the mod loading ID here. It can be found in \Steam\steamapps\workshop\modID\mods\modName\info.txt
+MODS="${MODS:-}"
+# Enter the foldername of the mod found in \Steam\steamapps\workshop\modID\mods\modName\media\maps\
+MAP="${MAP:-"Muldraugh, KY"}"
+# Kick clients whose game files don't match the server's.
+DO_LUA_CHECKSUM="${DO_LUA_CHECKSUM:-true}"
+# Deny login if the server is overloaded
+DENY_LOGIN_ON_OVERLOADED_SERVER="${DENY_LOGIN_ON_OVERLOADED_SERVER:-true}"
+# Shows the server on the in-game browser. (Note: Steam-enabled servers are always visible in the Steam server browser)
+PUBLIC="${PUBLIC:-false}"
+# Name of the server displayed in the in-game browser and, if applicable, the Steam browser
+PUBLIC_NAME="${PUBLIC_NAME:-"My PZ Server"}"
+# Description displayed in the in-game public server browser. Typing \n will create a new line in your description
+PUBLIC_DESCRIPTION="${PUBLIC_DESCRIPTION:-}"
+# Maximum number of players that can be on the server at one time. This excludes admins.
+MAX_PLAYERS="${MAX_PLAYERS:-32}"
+# Ping limit, in milliseconds, before a player is kicked from the server. (Set to 100 to disable)
+PING_LIMIT="${PING_LIMIT:-400}"
+# After X hours, all containers in the world will respawn loot. To spawn loot a container must have been looted at least once.
+HOURS_FOR_LOOT_RESPAWN="${HOURS_FOR_LOOT_RESPAWN:-0}"
+# Containers with a number of items greater, or equal to, this setting will not respawn
+MAX_ITEMS_FOR_LOOT_RESPAWN="${MAX_ITEMS_FOR_LOOT_RESPAWN:-4}"
+# Items will not respawn in buildings that players have barricaded or built in
+CONSTRUCTION_PREVENTS_LOOT_RESPAWN="${CONSTRUCTION_PREVENTS_LOOT_RESPAWN:-true}"
+# Remove player accounts from the whitelist after death. This prevents players creating a new character after death on Open=false servers
+DROP_OFF_WHITE_LIST_AFTER_DEATH="${DROP_OFF_WHITE_LIST_AFTER_DEATH:-false}"
+# All forms of fire are disabled - except for campfires
+NO_FIRE="${NO_FIRE:-false}"
+# If checked, every time a player dies a global message will be displayed in the chat
+ANNOUNCE_DEATH="${ANNOUNCE_DEATH:-false}"
+# The number of in-game minutes it takes to read one page of a book
+MINUTES_PER_PAGE="${MINUTES_PER_PAGE:-1.0}"
+# Loaded parts of the map are saved after this set number of real-world minutes have passed.
+SAVE_WORLD_EVERY_MINUTES="${SAVE_WORLD_EVERY_MINUTES:-0}"
+# Both admins and players can claim safehouses
+PLAYER_SAFEHOUSE="${PLAYER_SAFEHOUSE:-false}"
+# Only admins can claim safehouses
+ADMIN_SAFEHOUSE="${ADMIN_SAFEHOUSE:-false}"
+# Allow non-members to enter a safehouse without being invited
+SAFEHOUSE_ALLOW_TREPASS="${SAFEHOUSE_ALLOW_TREPASS:-true}"
+# Allow fire to damage safehouses
+SAFEHOUSE_ALLOW_FIRE="${SAFEHOUSE_ALLOW_FIRE:-true}"
+# Allow non-members to take items from safehouses
+SAFEHOUSE_ALLOW_LOOT="${SAFEHOUSE_ALLOW_LOOT:-true}"
+# Players will respawn in a safehouse that they were a member of before they died
+SAFEHOUSE_ALLOW_RESPAWN="${SAFEHOUSE_ALLOW_RESPAWN:-false}"
+# Players must have survived this number of in-game days before they are allowed to claim a safehouse
+SAFEHOUSE_DAY_SURVIVED_TO_CLAIM="${SAFEHOUSE_DAY_SURVIVED_TO_CLAIM:-0}"
+# Players are automatically removed from a safehouse they have not visited for this many real-world hours
+SAFE_HOUSE_REMOVAL_TIME="${SAFE_HOUSE_REMOVAL_TIME:-144}"
+# Governs whether players can claim non-residential buildings.
+SAFEHOUSE_ALLOW_NON_RESIDENTIAL="${SAFEHOUSE_ALLOW_NON_RESIDENTIAL:-false}"
+# Allow players to destroy world objects with sledgehammers
+ALLOW_DESTRUCTION_BY_SLEDGEHAMMER="${ALLOW_DESTRUCTION_BY_SLEDGEHAMMER:-true}"
+# Allow players to destroy world objects only in their safehouse (require AllowDestructionBySledgehammer to true).
+SLEDGEHAMMER_ONLY_IN_SAFEHOUSE="${SLEDGEHAMMER_ONLY_IN_SAFEHOUSE:-false}"
+# Kick players that appear to be moving faster than is possible. May be buggy -- use with caution.
+KICK_FAST_PLAYERS="${KICK_FAST_PLAYERS:-false}"
+# ServerPlayerID determines if a character is from another server, or single player. This value may be changed by soft resets.
+SERVER_PLAYER_ID="${SERVER_PLAYER_ID:-934857515}"
+# The port for the RCON (Remote Console)
+RCON_PORT="${RCON_PORT:-27015}"
+# RCON password (Pick a strong password)
+RCON_PASSWORD="${RCON_PASSWORD:-}"
+# Enables global text chat integration with a Discord channel
+DISCORD_ENABLE="${DISCORD_ENABLE:-false}"
+# Discord bot access token
+DISCORD_TOKEN="${DISCORD_TOKEN:-}"
+# The Discord channel name. (Try the separate channel ID option if having difficulties)
+DISCORD_CHANNEL="${DISCORD_CHANNEL:-}"
+# The Discord channel ID. (Use if having difficulties with Discord channel name option)
+DISCORD_CHANNEL_ID="${DISCORD_CHANNEL_ID:-}"
+# Clients must know this password to join the server. (Ignored when hosting a server via the Host button)
+PASSWORD="${PASSWORD:-}"
+# Limits the number of different accounts a single Steam user may create on this server. Ignored when using the Hosts button.
+MAX_ACCOUNTS_PER_USER="${MAX_ACCOUNTS_PER_USER:-0}"
+# Allow co-op/splitscreen players
+ALLOW_COOP="${ALLOW_COOP:-true}"
+# Players are allowed to sleep when their survivor becomes tired, but they do not NEED to sleep
+SLEEP_ALLOWED="${SLEEP_ALLOWED:-false}"
+# Players get tired and need to sleep. (Ignored if SleepAllowed=false)
+SLEEP_NEEDED="${SLEEP_NEEDED:-false}"
+# If true, players can be knocked down
+KNOCKED_DOWN_ALLOWED="${KNOCKED_DOWN_ALLOWED:-true}"
+# If true, sneaking players are hidden from others
+SNEAK_MODE_HIDE_FROM_OTHER_PLAYERS="${SNEAK_MODE_HIDE_FROM_OTHER_PLAYERS:-true}"
+# List Workshop Mod IDs for the server to download. Each must be separated by a semicolon.
+WORKSHOP_ITEMS="${WORKSHOP_ITEMS:-}"
+# Show Steam usernames and avatars in the Players list. Can be true (visible to everyone), false (visible to no one), or admin (visible to only admins)
+STEAM_SCOREBOARD="${STEAM_SCOREBOARD:-true}"
+# Attempt to configure a UPnP-enabled internet gateway to automatically setup port forwarding rules.
+UPNP="${UPNP:-true}"
+# VOIP is enabled when checked
+VOICE_ENABLE="${VOICE_ENABLE:-true}"
+# The minimum tile distance over which VOIP sounds can be heard.
+VOICE_MIN_DISTANCE="${VOICE_MIN_DISTANCE:-10.0}"
+# The maximum tile distance over which VOIP sounds can be heard.
+VOICE_MAX_DISTANCE="${VOICE_MAX_DISTANCE:-100.0}"
+# Toggle directional audio for VOIP
+VOICE_3D="${VOICE_3D:-true}"
+# Maximum speed limit for vehicles
+SPEED_LIMIT="${SPEED_LIMIT:-70.0}"
+# Enable login queue for server
+LOGIN_QUEUE_ENABLED="${LOGIN_QUEUE_ENABLED:-false}"
+# Timeout for login queue connection
+LOGIN_QUEUE_CONNECT_TIMEOUT="${LOGIN_QUEUE_CONNECT_TIMEOUT:-60}"
+# Set the IP from which the server is broadcast. This is for network configurations with multiple IP addresses, such as server farms
+SERVER_BROWSER_ANNOUNCED_IP="${SERVER_BROWSER_ANNOUNCED_IP:-}"
+# Players can respawn in-game at the coordinates where they died
+PLAYER_RESPAWN_WITH_SELF="${PLAYER_RESPAWN_WITH_SELF:-false}"
+# Players can respawn in-game at a split screen / Remote Play player's location
+PLAYER_RESPAWN_WITH_OTHER="${PLAYER_RESPAWN_WITH_OTHER:-false}"
+# Governs how fast time passes while players sleep. Value multiplies the speed of the time that passes during sleeping.
+FAST_FORWARD_MULTIPLIER="${FAST_FORWARD_MULTIPLIER:-40.0}"
+# Safehouse acts like a normal house if a member of the safehouse is connected (so secure when players are offline)
+DISABLE_SAFEHOUSE_WHEN_PLAYER_CONNECTED="${DISABLE_SAFEHOUSE_WHEN_PLAYER_CONNECTED:-false}"
+# Players can create factions when true
+FACTION="${FACTION:-true}"
+# Players must survive this number of in-game days before being allowed to create a faction
+FACTION_DAY_SURVIVED_TO_CREATE="${FACTION_DAY_SURVIVED_TO_CREATE:-0}"
+# Number of players required as faction members before the faction owner can create a group tag
+FACTION_PLAYERS_REQUIRED_FOR_TAG="${FACTION_PLAYERS_REQUIRED_FOR_TAG:-1}"
+# Disables radio transmissions from players with an access level
+DISABLE_RADIO_STAFF="${DISABLE_RADIO_STAFF:-false}"
+# Disables radio transmissions from players with 'admin' access level
+DISABLE_RADIO_ADMIN="${DISABLE_RADIO_ADMIN:-true}"
+# Disables radio transmissions from players with 'gm' access level
+DISABLE_RADIO_GM="${DISABLE_RADIO_GM:-true}"
+# Disables radio transmissions from players with 'overseer' access level
+DISABLE_RADIO_OVERSEER="${DISABLE_RADIO_OVERSEER:-false}"
+# Disables radio transmissions from players with 'moderator' access level
+DISABLE_RADIO_MODERATOR="${DISABLE_RADIO_MODERATOR:-false}"
+# Disables radio transmissions from invisible players
+DISABLE_RADIO_INVISIBLE="${DISABLE_RADIO_INVISIBLE:-true}"
+# Semicolon-separated list of commands that will not be written to the cmd.txt server log.
+CLIENT_COMMAND_FILTER="${CLIENT_COMMAND_FILTER:-"-vehicle.*;+vehicle.damageWindow;+vehicle.fixPart;+vehicle.installPart;+vehicle.uninstallPart"}"
+# Semicolon-separated list of actions that will be written to the ClientActionLogs.txt server log.
+CLIENT_ACTION_LOGS="${CLIENT_ACTION_LOGS:-"ISEnterVehicle;ISExitVehicle;ISTakeEngineParts;"}"
+# Track changes in player perk levels in PerkLog.txt server log
+PERK_LOGS="${PERK_LOGS:-true}"
+# Maximum number of items that can be placed in a container. Zero means there is no limit.
+ITEM_NUMBERS_LIMIT_PER_CONTAINER="${ITEM_NUMBERS_LIMIT_PER_CONTAINER:-0}"
+# Number of days before old blood splats are removed. Zero means they will never disappear.
+BLOOD_SPLAT_LIFESPAN_DAYS="${BLOOD_SPLAT_LIFESPAN_DAYS:-0}"
+# Allow use of non-ASCII (cyrillic etc) characters in usernames
+ALLOW_NON_ASCII_USERNAME="${ALLOW_NON_ASCII_USERNAME:-false}"
+
+BAN_KICK_GLOBAL_SOUND="${BAN_KICK_GLOBAL_SOUND:-true}"
+
+# If enabled, when HoursForCorpseRemoval triggers, it will also remove player’s corpses from the ground.
+REMOVE_PLAYER_CORPSES_ON_CORPSE_REMOVAL="${REMOVE_PLAYER_CORPSES_ON_CORPSE_REMOVAL:-false}"
+# If true, player can use the "delete all" button on bins.
+TRASH_DELETE_ALL="${TRASH_DELETE_ALL:-false}"
+# If true, player can hit again when struck by another player.
+PVP_MELEE_WHILE_HIT_REACTION="${PVP_MELEE_WHILE_HIT_REACTION:-false}"
+# If true, players will have to mouse over someone to see their display name.
+MOUSE_OVER_TO_SEE_DISPLAY_NAME="${MOUSE_OVER_TO_SEE_DISPLAY_NAME:-true}"
+# If true, automatically hide the player you can't see (like zombies).
+HIDE_PLAYERS_BEHIND_YOU="${HIDE_PLAYERS_BEHIND_YOU:-true}"
+# Damage multiplier for PVP melee attacks.
+PVP_MELEE_DAMAGE_MODIFIER="${PVP_MELEE_DAMAGE_MODIFIER:-30.0}"
+# Damage multiplier for PVP ranged attacks.
+PVP_FIREARM_DAMAGE_MODIFIER="${PVP_FIREARM_DAMAGE_MODIFIER:-50.0}"
+# Modify the range of zombie attraction to cars. (Lower values can help with lag.)
+CAR_ENGINE_ATTRACTION_MODIFIER="${CAR_ENGINE_ATTRACTION_MODIFIER:-0.5}"
+# Governs whether players bump (and knock over) other players when running through them.
+PLAYER_BUMP_PLAYER="${PLAYER_BUMP_PLAYER:-false}"
+# Controls display of remote players on the in-game map. 1=Hidden 2=Friends 3=Everyone
+MAP_REMOTE_PLAYER_VISIBILITY="${MAP_REMOTE_PLAYER_VISIBILITY:-1}"
+# Number of backups to keep
+BACKUPS_COUNT="${BACKUPS_COUNT:-5}"
+# Enable backups on server start
+BACKUPS_ON_START="${BACKUPS_ON_START:-true}"
+# Enable backups on version change
+BACKUPS_ON_VERSION_CHANGE="${BACKUPS_ON_VERSION_CHANGE:-true}"
+# Period between backups
+BACKUPS_PERIOD="${BACKUPS_PERIOD:-0}"
+# Disables anti-cheat protection for type 1.
+ANTI_CHEAT_PROTECTION_TYPE_1="${ANTI_CHEAT_PROTECTION_TYPE_1:-true}"
+# Disables anti-cheat protection for type 2.
+ANTI_CHEAT_PROTECTION_TYPE_2="${ANTI_CHEAT_PROTECTION_TYPE_2:-true}"
+# Disables anti-cheat protection for type 3.
+ANTI_CHEAT_PROTECTION_TYPE_3="${ANTI_CHEAT_PROTECTION_TYPE_3:-true}"
+# Disables anti-cheat protection for type 4.
+ANTI_CHEAT_PROTECTION_TYPE_4="${ANTI_CHEAT_PROTECTION_TYPE_4:-true}"
+# Disables anti-cheat protection for type 5.
+ANTI_CHEAT_PROTECTION_TYPE_5="${ANTI_CHEAT_PROTECTION_TYPE_5:-true}"
+# Disables anti-cheat protection for type 6.
+ANTI_CHEAT_PROTECTION_TYPE_6="${ANTI_CHEAT_PROTECTION_TYPE_6:-true}"
+# Disables anti-cheat protection for type 7.
+ANTI_CHEAT_PROTECTION_TYPE_7="${ANTI_CHEAT_PROTECTION_TYPE_7:-true}"
+# Disables anti-cheat protection for type 8.
+ANTI_CHEAT_PROTECTION_TYPE_8="${ANTI_CHEAT_PROTECTION_TYPE_8:-true}"
+# Disables anti-cheat protection for type 9.
+ANTI_CHEAT_PROTECTION_TYPE_9="${ANTI_CHEAT_PROTECTION_TYPE_9:-true}"
+# Disables anti-cheat protection for type 10.
+ANTI_CHEAT_PROTECTION_TYPE_10="${ANTI_CHEAT_PROTECTION_TYPE_10:-true}"
+# Disables anti-cheat protection for type 11.
+ANTI_CHEAT_PROTECTION_TYPE_11="${ANTI_CHEAT_PROTECTION_TYPE_11:-true}"
+# Disables anti-cheat protection for type 12.
+ANTI_CHEAT_PROTECTION_TYPE_12="${ANTI_CHEAT_PROTECTION_TYPE_12:-true}"
+# Disables anti-cheat protection for type 13.
+ANTI_CHEAT_PROTECTION_TYPE_13="${ANTI_CHEAT_PROTECTION_TYPE_13:-true}"
+# Disables anti-cheat protection for type 14.
+ANTI_CHEAT_PROTECTION_TYPE_14="${ANTI_CHEAT_PROTECTION_TYPE_14:-true}"
+# Disables anti-cheat protection for type 15.
+ANTI_CHEAT_PROTECTION_TYPE_15="${ANTI_CHEAT_PROTECTION_TYPE_15:-true}"
+# Disables anti-cheat protection for type 16.
+ANTI_CHEAT_PROTECTION_TYPE_16="${ANTI_CHEAT_PROTECTION_TYPE_16:-true}"
+# Disables anti-cheat protection for type 17.
+ANTI_CHEAT_PROTECTION_TYPE_17="${ANTI_CHEAT_PROTECTION_TYPE_17:-true}"
+# Disables anti-cheat protection for type 18.
+ANTI_CHEAT_PROTECTION_TYPE_18="${ANTI_CHEAT_PROTECTION_TYPE_18:-true}"
+# Disables anti-cheat protection for type 19.
+ANTI_CHEAT_PROTECTION_TYPE_19="${ANTI_CHEAT_PROTECTION_TYPE_19:-true}"
+# Disables anti-cheat protection for type 20.
+ANTI_CHEAT_PROTECTION_TYPE_20="${ANTI_CHEAT_PROTECTION_TYPE_20:-true}"
+# Disables anti-cheat protection for type 21.
+ANTI_CHEAT_PROTECTION_TYPE_21="${ANTI_CHEAT_PROTECTION_TYPE_21:-true}"
+# Disables anti-cheat protection for type 22.
+ANTI_CHEAT_PROTECTION_TYPE_22="${ANTI_CHEAT_PROTECTION_TYPE_22:-true}"
+# Disables anti-cheat protection for type 23.
+ANTI_CHEAT_PROTECTION_TYPE_23="${ANTI_CHEAT_PROTECTION_TYPE_23:-true}"
+# Disables anti-cheat protection for type 24.
+ANTI_CHEAT_PROTECTION_TYPE_24="${ANTI_CHEAT_PROTECTION_TYPE_24:-true}"
+# Threshold value multiplier for anti-cheat protection: type 2.
+ANTI_CHEAT_PROTECTION_TYPE_2_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_2_THRESHOLD_MULTIPLIER:-3.0}"
+# Threshold value multiplier for anti-cheat protection: type 3.
+ANTI_CHEAT_PROTECTION_TYPE_3_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_3_THRESHOLD_MULTIPLIER:-1.0}"
+# Threshold value multiplier for anti-cheat protection: type 4.
+ANTI_CHEAT_PROTECTION_TYPE_4_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_4_THRESHOLD_MULTIPLIER:-1.0}"
+# Threshold value multiplier for anti-cheat protection: type 9.
+ANTI_CHEAT_PROTECTION_TYPE_9_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_9_THRESHOLD_MULTIPLIER:-1.0}"
+# Threshold value multiplier for anti-cheat protection: type 15.
+ANTI_CHEAT_PROTECTION_TYPE_15_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_15_THRESHOLD_MULTIPLIER:-1.0}"
+# Threshold value multiplier for anti-cheat protection: type 20.
+ANTI_CHEAT_PROTECTION_TYPE_20_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_20_THRESHOLD_MULTIPLIER:-1.0}"
+# Threshold value multiplier for anti-cheat protection: type 22.
+ANTI_CHEAT_PROTECTION_TYPE_22_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_22_THRESHOLD_MULTIPLIER:-1.0}"
+# Threshold value multiplier for anti-cheat protection: type 24.
+ANTI_CHEAT_PROTECTION_TYPE_24_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_24_THRESHOLD_MULTIPLIER:-6.0}"
+
+# Disable automatic export
+set +a

--- a/server/env/server-sandbox-vars.sh
+++ b/server/env/server-sandbox-vars.sh
@@ -1,0 +1,769 @@
+#!/bin/bash
+# Project Zomboid Server Sandbox Variables
+#
+# This script defines default environment variables for Project Zomboid
+# server sandbox configuration that correspond to the sandbox settings in the game.
+# These variables control world generation, gameplay difficulty, zombie behavior,
+# survival mechanics, vehicle settings, and other sandbox-specific parameters.
+#
+# These environment variables can be overridden at runtime to customize
+# sandbox configuration when running in Docker or other containerized environments.
+# Each variable uses the bash parameter expansion syntax ${VAR:-default} to
+# provide fallback values if not explicitly set.
+#
+# Usage:
+#   Source this file before generating sandbox configuration:
+#   source ./server-sandbox-vars.sh
+#
+# Docker Usage:
+#   Override any variable using Docker's -e flag:
+#   docker run -e ZOMBIES="5" -e XP_MULTIPLIER="2.0" -e PVP="false" <image>
+#
+# Configuration Categories:
+#   - World settings (version, zombie distribution, day length)
+#   - Utilities and infrastructure (water/electricity shutoff)
+#   - Loot and item spawning (food, weapons, medical supplies)
+#   - Environmental factors (temperature, rain, erosion)
+#   - Character progression (XP multipliers, free points)
+#   - Survival mechanics (nutrition, injury severity, corpse removal)
+#   - Vehicle system (spawn rates, fuel, damage, traffic)
+#   - Map configuration (mini-map, world map visibility)
+#   - Zombie behavior (speed, strength, cognition, population)
+#   - Advanced zombie settings (respawn, rally mechanics)
+
+# Enable automatic export of all variables
+set -a
+
+VERSION="${VERSION:-5}"
+
+# Changing this sets the "Population Multiplier" advanced option. Default=Normal
+# 1 = Insane
+# 2 = Very High
+# 3 = High
+# 4 = Normal
+# 5 = Low
+ZOMBIES="${ZOMBIES:-4}"
+
+# Default=Urban Focused
+# 1 = Urban Focused
+DISTRIBUTION="${DISTRIBUTION:-1}"
+
+# Default=1 Hour
+# 1 = 15 Minutes
+# 2 = 30 Minutes
+# 3 = 1 Hour
+# 4 = 2 Hours
+# 5 = 3 Hours
+# 6 = 4 Hours
+# 7 = 5 Hours
+# 8 = 6 Hours
+# 9 = 7 Hours
+# 10 = 8 Hours
+# 11 = 9 Hours
+# 12 = 10 Hours
+# 13 = 11 Hours
+# 14 = 12 Hours
+# 15 = 13 Hours
+# 16 = 14 Hours
+# 17 = 15 Hours
+# 18 = 16 Hours
+# 19 = 17 Hours
+# 20 = 18 Hours
+# 21 = 19 Hours
+# 22 = 20 Hours
+# 23 = 21 Hours
+# 24 = 22 Hours
+# 25 = 23 Hours
+DAY_LENGTH="${DAY_LENGTH:-3}"
+
+START_YEAR="${START_YEAR:-1}"
+
+# Default=July
+# 1 = January
+# 2 = February
+# 3 = March
+# 4 = April
+# 5 = May
+# 6 = June
+# 7 = July
+# 8 = August
+# 9 = September
+# 10 = October
+# 11 = November
+START_MONTH="${START_MONTH:-7}"
+
+START_DAY="${START_DAY:-9}"
+
+# Default=9 AM
+# 1 = 7 AM
+# 2 = 9 AM
+# 3 = 12 PM
+# 4 = 2 PM
+# 5 = 5 PM
+# 6 = 9 PM
+# 7 = 12 AM
+# 8 = 2 AM
+START_TIME="${START_TIME:-2}"
+
+# Default=0-30 Days
+# 1 = Instant
+# 2 = 0-30 Days
+# 3 = 0-2 Months
+# 4 = 0-6 Months
+# 5 = 0-1 Year
+# 6 = 0-5 Years
+# 7 = 2-6 Months
+WATER_SHUT="${WATER_SHUT:-2}"
+
+# Default=0-30 Days
+# 1 = Instant
+# 2 = 0-30 Days
+# 3 = 0-2 Months
+# 4 = 0-6 Months
+# 5 = 0-1 Year
+# 6 = 0-5 Years
+# 7 = 2-6 Months
+ELEC_SHUT="${ELEC_SHUT:-2}"
+
+# Minimum=-1 Maximum=2147483647 Default=14
+WATER_SHUT_MODIFIER="${WATER_SHUT_MODIFIER:-14}"
+
+# Minimum=-1 Maximum=2147483647 Default=14
+ELEC_SHUT_MODIFIER="${ELEC_SHUT_MODIFIER:-14}"
+
+# Default=Rare
+# 1 = None (not recommended)
+# 2 = Insanely Rare
+# 3 = Extremely Rare
+# 4 = Rare
+# 5 = Normal
+# 6 = Common
+FOOD_LOOT="${FOOD_LOOT:-4}"
+
+# Default=Rare
+# 1 = None (not recommended)
+# 2 = Insanely Rare
+# 3 = Extremely Rare
+# 4 = Rare
+# 5 = Normal
+# 6 = Common
+CANNED_FOOD_LOOT="${CANNED_FOOD_LOOT:-4}"
+
+# Default=Rare
+# 1 = None (not recommended)
+# 2 = Insanely Rare
+# 3 = Extremely Rare
+# 4 = Rare
+# 5 = Normal
+# 6 = Common
+LITERATURE_LOOT="${LITERATURE_LOOT:-4}"
+
+# Seeds, Nails, Saws, Fishing Rods, various tools, etc... Default=Rare
+# 1 = None (not recommended)
+# 2 = Insanely Rare
+# 3 = Extremely Rare
+# 4 = Rare
+# 5 = Normal
+# 6 = Common
+SURVIVAL_GEARS_LOOT="${SURVIVAL_GEARS_LOOT:-4}"
+
+# Default=Rare
+# 1 = None (not recommended)
+# 2 = Insanely Rare
+# 3 = Extremely Rare
+# 4 = Rare
+# 5 = Normal
+# 6 = Common
+MEDICAL_LOOT="${MEDICAL_LOOT:-4}"
+
+# Default=Rare
+# 1 = None (not recommended)
+# 2 = Insanely Rare
+# 3 = Extremely Rare
+# 4 = Rare
+# 5 = Normal
+# 6 = Common
+WEAPON_LOOT="${WEAPON_LOOT:-4}"
+
+# Default=Rare
+# 1 = None (not recommended)
+# 2 = Insanely Rare
+# 3 = Extremely Rare
+# 4 = Rare
+# 5 = Normal
+# 6 = Common
+RANGED_WEAPON_LOOT="${RANGED_WEAPON_LOOT:-4}"
+
+# Default=Rare
+# 1 = None (not recommended)
+# 2 = Insanely Rare
+# 3 = Extremely Rare
+# 4 = Rare
+# 5 = Normal
+# 6 = Common
+AMMO_LOOT="${AMMO_LOOT:-4}"
+
+# Default=Rare
+# 1 = None (not recommended)
+# 2 = Insanely Rare
+# 3 = Extremely Rare
+# 4 = Rare
+# 5 = Normal
+# 6 = Common
+MECHANICS_LOOT="${MECHANICS_LOOT:-4}"
+
+# Everything else. Also affects foraging for all items in Town/Road zones. Default=Rare
+# 1 = None (not recommended)
+# 2 = Insanely Rare
+# 3 = Extremely Rare
+# 4 = Rare
+# 5 = Normal
+# 6 = Common
+OTHER_LOOT="${OTHER_LOOT:-4}"
+
+# Controls the global temperature. Default=Normal
+# 1 = Very Cold
+# 2 = Cold
+# 3 = Normal
+# 4 = Hot
+TEMPERATURE="${TEMPERATURE:-3}"
+
+# Controls how often it rains. Default=Normal
+# 1 = Very Dry
+# 2 = Dry
+# 3 = Normal
+# 4 = Rainy
+RAIN="${RAIN:-3}"
+
+# Number of days until 100% growth. Default=Normal (100 Days)
+# 1 = Very Fast (20 Days)
+# 2 = Fast (50 Days)
+# 3 = Normal (100 Days)
+# 4 = Slow (200 Days)
+EROSION_SPEED="${EROSION_SPEED:-3}"
+
+# Number of days until 100% growth. -1 means no growth. Zero means use the Erosion Speed option. Maximum 36,500 (100 years). Minimum=-1 Maximum=36500 Default=0
+EROSION_DAYS="${EROSION_DAYS:-0}"
+
+# Modifies the base XP gain from actions by this number. Minimum=0.00 Maximum=1000.00 Default=1.00
+XP_MULTIPLIER="${XP_MULTIPLIER:-1.0}"
+
+# Use this to multiply or reduce engine general loudness. Minimum=0.00 Maximum=100.00 Default=1.00
+ZOMBIE_ATTRACTION_MULTIPLIER="${ZOMBIE_ATTRACTION_MULTIPLIER:-1.0}"
+
+# Governs whether cars are locked, need keys to start etc.
+VEHICLE_EASY_USE="${VEHICLE_EASY_USE:-false}"
+
+# Controls the speed of plant growth. Default=Normal
+# 1 = Very Fast
+# 2 = Fast
+# 3 = Normal
+# 4 = Slow
+FARMING="${FARMING:-3}"
+
+# Controls the time it takes for food to break down in a composter. Default=2 Weeks
+# 1 = 1 Week
+# 2 = 2 Weeks
+# 3 = 3 Weeks
+# 4 = 4 Weeks
+# 5 = 6 Weeks
+# 6 = 8 Weeks
+# 7 = 10 Weeks
+COMPOST_TIME="${COMPOST_TIME:-2}"
+
+# How fast character's hunger, thirst and fatigue will decrease. Default=Normal
+# 1 = Very Fast
+# 2 = Fast
+# 3 = Normal
+# 4 = Slow
+STATS_DECREASE="${STATS_DECREASE:-3}"
+
+# Controls the abundance of fish and general forage. Default=Normal
+# 1 = Very Poor
+# 2 = Poor
+# 3 = Normal
+# 4 = Abundant
+NATURE_ABUNDANCE="${NATURE_ABUNDANCE:-3}"
+
+# Default=Sometimes
+# 1 = Never
+# 2 = Extremely Rare
+# 3 = Rare
+# 4 = Sometimes
+# 5 = Often
+ALARM="${ALARM:-4}"
+
+# How frequently homes and buildings will be discovered locked Default=Very Often
+# 1 = Never
+# 2 = Extremely Rare
+# 3 = Rare
+# 4 = Sometimes
+# 5 = Often
+LOCKED_HOUSES="${LOCKED_HOUSES:-6}"
+
+# Spawn with chips, water bottle, school bag, baseball bat and a hammer.
+STARTER_KIT="${STARTER_KIT:-false}"
+
+# Nutritional value of food affects the player's condition.
+NUTRITION="${NUTRITION:-true}"
+
+# Define how fast the food will spoil inside or outside fridge. Default=Normal
+# 1 = Very Fast
+# 2 = Fast
+# 3 = Normal
+# 4 = Slow
+FOOD_ROT_SPEED="${FOOD_ROT_SPEED:-3}"
+
+# Define how much a fridge will be effective. Default=Normal
+# 1 = Very Low
+# 2 = Low
+# 3 = Normal
+# 4 = High
+FRIDGE_FACTOR="${FRIDGE_FACTOR:-3}"
+
+# Items will respawn in already-looted containers in towns and trailer parks. Items will not respawn in player-made containers. Default=None
+# 1 = None
+# 2 = Every Day
+# 3 = Every Week
+# 4 = Every Month
+LOOT_RESPAWN="${LOOT_RESPAWN:-1}"
+
+# When > 0, loot will not respawn in zones that have been visited within this number of in-game hours. Minimum=0 Maximum=2147483647 Default=0
+SEEN_HOURS_PREVENT_LOOT_RESPAWN="${SEEN_HOURS_PREVENT_LOOT_RESPAWN:-0}"
+
+# A comma-separated list of item types that will be removed after HoursForWorldItemRemoval hours.
+WORLD_ITEM_REMOVAL_LIST="${WORLD_ITEM_REMOVAL_LIST:-"Base.Hat,Base.Glasses,Base.Maggots"}"
+
+# Number of hours since an item was dropped on the ground before it is removed.  Items are removed the next time that part of the map is loaded.  Zero means items are not removed. Minimum=0.00 Maximum=2147483647.00 Default=24.00
+HOURS_FOR_WORLD_ITEM_REMOVAL="${HOURS_FOR_WORLD_ITEM_REMOVAL:-24.0}"
+
+# If true, any items *not* in WorldItemRemovalList will be removed.
+ITEM_REMOVAL_LIST_BLACKLIST_TOGGLE="${ITEM_REMOVAL_LIST_BLACKLIST_TOGGLE:-false}"
+
+# This will affect starting world erosion and food spoilage. Default=0
+# 1 = 0
+# 2 = 1
+# 3 = 2
+# 4 = 3
+# 5 = 4
+# 6 = 5
+# 7 = 6
+# 8 = 7
+# 9 = 8
+# 10 = 9
+# 11 = 10
+# 12 = 11
+TIME_SINCE_APO="${TIME_SINCE_APO:-1}"
+
+# Will influence how much water the plant will lose per day and their ability to avoid disease. Default=Normal
+# 1 = Very High
+# 2 = High
+# 3 = Normal
+# 4 = Low
+PLANT_RESILIENCE="${PLANT_RESILIENCE:-3}"
+
+# Controls the yield of plants when harvested. Default=Normal
+# 1 = Very Poor
+# 2 = Poor
+# 3 = Normal
+# 4 = Abundant
+PLANT_ABUNDANCE="${PLANT_ABUNDANCE:-3}"
+
+# Recovery from being tired from performing actions Default=Normal
+# 1 = Very Fast
+# 2 = Fast
+# 3 = Normal
+# 4 = Slow
+END_REGEN="${END_REGEN:-3}"
+
+# How regularly helicopters pass over the event zone. Default=Once
+# 1 = Never
+# 2 = Once
+# 3 = Sometimes
+HELICOPTER="${HELICOPTER:-2}"
+
+# How often zombie attracting metagame events like distant gunshots will occur. Default=Sometimes
+# 1 = Never
+# 2 = Sometimes
+META_EVENT="${META_EVENT:-2}"
+
+# Governs night-time metagame events during the player's sleep. Default=Never
+# 1 = Never
+# 2 = Sometimes
+SLEEPING_EVENT="${SLEEPING_EVENT:-1}"
+
+# Increase/decrease the chance of electrical generators spawning on the map. Default=Sometimes
+# 1 = Extremely Rare
+# 2 = Rare
+# 3 = Sometimes
+# 4 = Often
+GENERATOR_SPAWNING="${GENERATOR_SPAWNING:-3}"
+
+# How much fuel is consumed per in-game hour. Minimum=0.00 Maximum=100.00 Default=1.00
+GENERATOR_FUEL_CONSUMPTION="${GENERATOR_FUEL_CONSUMPTION:-1.0}"
+
+# Increase/decrease probability of discovering randomized safe houses on the map: either burnt out, containing loot stashes, dead survivor bodies etc. Default=Rare
+# 1 = Never
+# 2 = Extremely Rare
+# 3 = Rare
+# 4 = Sometimes
+# 5 = Often
+SURVIVOR_HOUSE_CHANCE="${SURVIVOR_HOUSE_CHANCE:-3}"
+
+# Default=Rare
+# 1 = Never
+# 2 = Extremely Rare
+# 3 = Rare
+# 4 = Sometimes
+# 5 = Often
+VEHICLE_STORY_CHANCE="${VEHICLE_STORY_CHANCE:-3}"
+
+# Default=Rare
+# 1 = Never
+# 2 = Extremely Rare
+# 3 = Rare
+# 4 = Sometimes
+# 5 = Often
+ZONE_STORY_CHANCE="${ZONE_STORY_CHANCE:-3}"
+
+# Impacts on how often a looted map will have annotations marked on it by a deceased survivor. Default=Sometimes
+# 1 = Never
+# 2 = Extremely Rare
+# 3 = Rare
+# 4 = Sometimes
+# 5 = Often
+ANNOTATED_MAP_CHANCE="${ANNOTATED_MAP_CHANCE:-4}"
+
+# Adds free points during character creation. Minimum=-100 Maximum=100 Default=0
+CHARACTER_FREE_POINTS="${CHARACTER_FREE_POINTS:-0}"
+
+# Gives player-built constructions extra hit points so they are more resistant to zombie damage. Default=Normal
+# 1 = Very Low
+# 2 = Low
+# 3 = Normal
+# 4 = High
+CONSTRUCTION_BONUS_POINTS="${CONSTRUCTION_BONUS_POINTS:-3}"
+
+# Governs the ambient lighting at night. Default=Normal
+# 1 = Pitch Black
+# 2 = Dark
+# 3 = Normal
+NIGHT_DARKNESS="${NIGHT_DARKNESS:-3}"
+
+# Increase and decrease the impact injuries have on your body, and their healing time. Default=Normal
+# 1 = Low
+# 2 = Normal
+INJURY_SEVERITY="${INJURY_SEVERITY:-2}"
+
+# Enable or disable broken limbs when survivors receive injuries from impacts, zombie damage and falls.
+BONE_FRACTURE="${BONE_FRACTURE:-true}"
+
+# How long before zombie bodies disappear. Minimum=-1.00 Maximum=2147483647.00 Default=216.00
+HOURS_FOR_CORPSE_REMOVAL="${HOURS_FOR_CORPSE_REMOVAL:-216.0}"
+
+# Governs impact that nearby decaying bodies has on the player's health and emotions. Default=Normal
+# 1 = None
+# 2 = Low
+# 3 = Normal
+DECAYING_CORPSE_HEALTH_IMPACT="${DECAYING_CORPSE_HEALTH_IMPACT:-3}"
+
+# How much blood is sprayed on floor and walls. Default=Normal
+# 1 = None
+# 2 = Low
+# 3 = Normal
+# 4 = High
+BLOOD_LEVEL="${BLOOD_LEVEL:-3}"
+
+# Governs how quickly clothing degrades, becomes dirty, and bloodied. Default=Normal
+# 1 = Disabled
+# 2 = Slow
+# 3 = Normal
+CLOTHING_DEGRADATION="${CLOTHING_DEGRADATION:-3}"
+
+FIRE_SPREAD="${FIRE_SPREAD:-true}"
+
+# Number of in-game days before rotten food is removed from the map. -1 means rotten food is never removed. Minimum=-1 Maximum=2147483647 Default=-1
+DAYS_FOR_ROTTEN_FOOD_REMOVAL="${DAYS_FOR_ROTTEN_FOOD_REMOVAL:--1}"
+
+# If enabled, generators will work on exterior tiles, allowing for example to power gas pump.
+ALLOW_EXTERIOR_GENERATOR="${ALLOW_EXTERIOR_GENERATOR:-true}"
+
+# Controls the maximum intensity of fog. Default=Normal
+# 1 = Normal
+# 2 = Moderate
+MAX_FOG_INTENSITY="${MAX_FOG_INTENSITY:-1}"
+
+# Controls the maximum intensity of rain. Default=Normal
+# 1 = Normal
+# 2 = Moderate
+MAX_RAIN_FX_INTENSITY="${MAX_RAIN_FX_INTENSITY:-1}"
+
+# If disabled snow will not accumulate on ground but will still be visible on vegetation and rooftops.
+ENABLE_SNOW_ON_GROUND="${ENABLE_SNOW_ON_GROUND:-true}"
+
+# if disabled, tainted water will not have a warning marking it as such
+ENABLE_TAINTED_WATER_TEXT="${ENABLE_TAINTED_WATER_TEXT:-true}"
+
+# When enabled certain melee weapons will be able to strike multiple zombies in one hit.
+MULTI_HIT_ZOMBIES="${MULTI_HIT_ZOMBIES:-false}"
+
+# Chance of being bitten when a zombie attacks from behind. Default=High
+# 1 = Low
+# 2 = Medium
+REAR_VULNERABILITY="${REAR_VULNERABILITY:-3}"
+
+# Disable to walk unimpeded while melee attacking.
+ATTACK_BLOCK_MOVEMENTS="${ATTACK_BLOCK_MOVEMENTS:-true}"
+
+ALL_CLOTHES_UNLOCKED="${ALL_CLOTHES_UNLOCKED:-false}"
+
+# Governs how frequently cars are discovered on the map Default=Low
+# 1 = None
+# 2 = Very Low
+# 3 = Low
+# 4 = Normal
+CAR_SPAWN_RATE="${CAR_SPAWN_RATE:-3}"
+
+# Governs the chances of finding vehicles with gas in the tank. Default=Low
+# 1 = Low
+# 2 = Normal
+CHANCE_HAS_GAS="${CHANCE_HAS_GAS:-1}"
+
+# Governs how full gas tanks will be in discovered cars. Default=Low
+# 1 = Very Low
+# 2 = Low
+# 3 = Normal
+# 4 = High
+# 5 = Very High
+INITIAL_GAS="${INITIAL_GAS:-2}"
+
+# Governs how full gas tanks in fuel station will be, initially. Default=Normal
+# 1 = Empty
+# 2 = Super Low
+# 3 = Very Low
+# 4 = Low
+# 5 = Normal
+# 6 = High
+# 7 = Very High
+# 8 = Full
+FUEL_STATION_GAS="${FUEL_STATION_GAS:-5}"
+
+# How gas-hungry vehicles on the map are. Minimum=0.00 Maximum=100.00 Default=1.00
+CAR_GAS_CONSUMPTION="${CAR_GAS_CONSUMPTION:-1.0}"
+
+# Default=Rare
+# 1 = Never
+# 2 = Extremely Rare
+# 3 = Rare
+# 4 = Sometimes
+# 5 = Often
+LOCKED_CAR="${LOCKED_CAR:-3}"
+
+# General condition of vehicles discovered on the map Default=Low
+# 1 = Very Low
+# 2 = Low
+# 3 = Normal
+# 4 = High
+CAR_GENERAL_CONDITION="${CAR_GENERAL_CONDITION:-2}"
+
+# Governs the amount of damage dealt to vehicles that crash. Default=Normal
+# 1 = Very Low
+# 2 = Low
+# 3 = Normal
+# 4 = High
+CAR_DAMAGE_ON_IMPACT="${CAR_DAMAGE_ON_IMPACT:-3}"
+
+# Damage received by the player from the car in a collision. Default=None
+# 1 = None
+# 2 = Low
+# 3 = Normal
+# 4 = High
+DAMAGE_TO_PLAYER_FROM_HIT_BY_A_CAR="${DAMAGE_TO_PLAYER_FROM_HIT_BY_A_CAR:-1}"
+
+# Enable or disable traffic jams that spawn on the main roads of the map.
+TRAFFIC_JAM="${TRAFFIC_JAM:-true}"
+
+# How frequently cars will be discovered with an alarm. Default=Extremely Rare
+# 1 = Never
+# 2 = Extremely Rare
+# 3 = Rare
+# 4 = Sometimes
+# 5 = Often
+CAR_ALARM="${CAR_ALARM:-2}"
+
+# Enable or disable player getting damage from being in a car accident.
+PLAYER_DAMAGE_FROM_CRASH="${PLAYER_DAMAGE_FROM_CRASH:-true}"
+
+# How many in-game hours before a wailing siren shuts off. Minimum=0.00 Maximum=168.00 Default=0.00
+SIREN_SHUTOFF_HOURS="${SIREN_SHUTOFF_HOURS:-0.0}"
+
+#  Governs whether player can discover a car that has been maintained and cared for after the infection struck. Default=Low
+# 1 = None
+# 2 = Low
+# 3 = Normal
+RECENTLY_SURVIVOR_VEHICLES="${RECENTLY_SURVIVOR_VEHICLES:-2}"
+
+# Enables vehicles to spawn.
+ENABLE_VEHICLES="${ENABLE_VEHICLES:-true}"
+
+# Governs if poisoning food is enabled. Default=True
+# 1 = True
+# 2 = False
+ENABLE_POISONING="${ENABLE_POISONING:-1}"
+
+# Default=In and around bodies
+# 1 = In and around bodies
+# 2 = In bodies only
+MAGGOT_SPAWN="${MAGGOT_SPAWN:-1}"
+
+# --------------------------------------------------------------
+# Nested categories for map settings
+ALLOW_MINI_MAP="${ALLOW_MINI_MAP:-false}"
+ALLOW_WORLD_MAP="${ALLOW_WORLD_MAP:-true}"
+MAP_ALL_KNOWN="${MAP_ALL_KNOWN:-false}"
+
+# --------------------------------------------------------------
+# Nested categories for zombie lore settings
+# Controls the zombie movement rate. Default=Fast Shamblers
+# 1 = Sprinters
+# 2 = Fast Shamblers
+# 3 = Shamblers
+SPEED="${SPEED:-2}"
+
+# Controls the damage zombies inflict per attack. Default=Normal
+# 1 = Superhuman
+# 2 = Normal
+# 3 = Weak
+STRENGTH="${STRENGTH:-2}"
+
+# Controls the difficulty to kill zombies. Default=Normal
+# 1 = Tough
+# 2 = Normal
+# 3 = Fragile
+TOUGHNESS="${TOUGHNESS:-2}"
+
+# Controls how the zombie virus spreads. Default=Blood + Saliva
+# 1 = Blood + Saliva
+# 2 = Saliva Only
+# 3 = Everyone's Infected
+TRANSMISSION="${TRANSMISSION:-1}"
+
+# Controls how quickly the infection takes effect. Default=2-3 Days
+# 1 = Instant
+# 2 = 0-30 Seconds
+# 3 = 0-1 Minutes
+# 4 = 0-12 Hours
+# 5 = 2-3 Days
+# 6 = 1-2 Weeks
+MORTALITY="${MORTALITY:-5}"
+
+# Controls how quickly corpses rise as zombies. Default=0-1 Minutes
+# 1 = Instant
+# 2 = 0-30 Seconds
+# 3 = 0-1 Minutes
+# 4 = 0-12 Hours
+# 5 = 2-3 Days
+REANIMATE="${REANIMATE:-3}"
+
+# Controls zombie intelligence. Default=Basic Navigation
+# 1 = Navigate + Use Doors
+# 2 = Navigate
+# 3 = Basic Navigation
+COGNITION="${COGNITION:-3}"
+
+# Controls which zombies can crawl under vehicles. Default=Often
+# 1 = Crawlers Only
+# 2 = Extremely Rare
+# 3 = Rare
+# 4 = Sometimes
+# 5 = Often
+# 6 = Very Often
+CRAWL_UNDER_VEHICLE="${CRAWL_UNDER_VEHICLE:-5}"
+
+# Controls how long zombies remember players after seeing or hearing. Default=Normal
+# 1 = Long
+# 2 = Normal
+# 3 = Short
+# 4 = None
+MEMORY="${MEMORY:-2}"
+
+# Controls zombie vision radius. Default=Normal
+# 1 = Eagle
+# 2 = Normal
+# 3 = Poor
+SIGHT="${SIGHT:-2}"
+
+# Controls zombie hearing radius. Default=Normal
+# 1 = Pinpoint
+# 2 = Normal
+# 3 = Poor
+HEARING="${HEARING:-2}"
+
+# Zombies that have not seen/heard player can attack doors and constructions while roaming.
+THUMP_NO_CHASING="${THUMP_NO_CHASING:-false}"
+
+# Governs whether or not zombies can destroy player constructions and defences.
+THUMP_ON_CONSTRUCTION="${THUMP_ON_CONSTRUCTION:-true}"
+
+# Governs whether zombies are more active during the day, or whether they act more nocturnally.  Active zombies will use the speed set in the "Speed" setting. Inactive zombies will be slower, and tend not to give chase. Default=Both
+# 1 = Both
+# 2 = Night
+ACTIVE_ONLY="${ACTIVE_ONLY:-1}"
+
+# Allows zombies to trigger house alarms when breaking through windows and doors.
+TRIGGER_HOUSE_ALARM="${TRIGGER_HOUSE_ALARM:-false}"
+
+# When enabled if multiple zombies are attacking they can drag you down to feed. Dependent on zombie strength.
+ZOMBIES_DRAG_DOWN="${ZOMBIES_DRAG_DOWN:-true}"
+
+# When enabled zombies will have a chance to lunge after climbing over a fence if you're too close.
+ZOMBIES_FENCE_LUNGE="${ZOMBIES_FENCE_LUNGE:-true}"
+
+# Default=Some zombies in the world will pretend to be dead
+# 1 = Some zombies in the world will pretend to be dead
+# 2 = Some zombies in the world, as well as some you 'kill', can pretend to be dead
+DISABLE_FAKE_DEAD="${DISABLE_FAKE_DEAD:-1}"
+
+# --------------------------------------------------------------
+# Nested categories for zombie settings
+# Set by the "Zombie Count" population option. 4.0 = Insane, Very High = 3.0, 2.0 = High, 1.0 = Normal, 0.35 = Low, 0.0 = None. Minimum=0.00 Maximum=4.00 Default=1.00
+POPULATION_MULTIPLIER="${POPULATION_MULTIPLIER:-1.0}"
+
+# Adjusts the desired population at the start of the game. Minimum=0.00 Maximum=4.00 Default=1.00
+POPULATION_START_MULTIPLIER="${POPULATION_START_MULTIPLIER:-1.0}"
+
+# Adjusts the desired population on the peak day. Minimum=0.00 Maximum=4.00 Default=1.50
+POPULATION_PEAK_MULTIPLIER="${POPULATION_PEAK_MULTIPLIER:-1.5}"
+
+# The day when the population reaches it's peak. Minimum=1 Maximum=365 Default=28
+POPULATION_PEAK_DAY="${POPULATION_PEAK_DAY:-28}"
+
+# The number of hours that must pass before zombies may respawn in a cell. If zero, spawning is disabled. Minimum=0.00 Maximum=8760.00 Default=72.00
+RESPAWN_HOURS="${RESPAWN_HOURS:-72.0}"
+
+# The number of hours that a chunk must be unseen before zombies may respawn in it. Minimum=0.00 Maximum=8760.00 Default=16.00
+RESPAWN_UNSEEN_HOURS="${RESPAWN_UNSEEN_HOURS:-16.0}"
+
+# The fraction of a cell's desired population that may respawn every RespawnHours. Minimum=0.00 Maximum=1.00 Default=0.10
+RESPAWN_MULTIPLIER="${RESPAWN_MULTIPLIER:-0.1}"
+
+# The number of hours that must pass before zombies migrate to empty parts of the same cell. If zero, migration is disabled. Minimum=0.00 Maximum=8760.00 Default=12.00
+REDISTRIBUTE_HOURS="${REDISTRIBUTE_HOURS:-12.0}"
+
+# The distance a zombie will try to walk towards the last sound it heard. Minimum=10 Maximum=1000 Default=100
+FOLLOW_SOUND_DISTANCE="${FOLLOW_SOUND_DISTANCE:-100}"
+
+# The size of groups real zombies form when idle. Zero means zombies don't form groups. Groups don't form inside buildings or forest zones. Minimum=0 Maximum=1000 Default=20
+RALLY_GROUP_SIZE="${RALLY_GROUP_SIZE:-20}"
+
+# The distance real zombies travel to form groups when idle. Minimum=5 Maximum=50 Default=20
+RALLY_TRAVEL_DISTANCE="${RALLY_TRAVEL_DISTANCE:-20}"
+
+# The distance between zombie groups. Minimum=5 Maximum=25 Default=15
+RALLY_GROUP_SEPARATION="${RALLY_GROUP_SEPARATION:-15}"
+
+# How close members of a group stay to the group's leader. Minimum=1 Maximum=10 Default=3
+RALLY_GROUP_RADIUS="${RALLY_GROUP_RADIUS:-3}"
+
+# Disable automatic export
+set +a


### PR DESCRIPTION
# Description
This pull request introduces three new environment configuration scripts for the Project Zomboid dedicated server:

1. **`server-init-flags.sh`** and
2. **`server-init-settings.sh`**,
3. **`server_sandbox_vars.lua`**

These scripts define default environment variables and in-game sandbox settings, allowing for easier customization when running the server in Docker or other containerized environments. The changes focus on improving server configurability and providing detailed documentation for each setting.

---

### Server Startup Configuration

* **`server/env/server-init-flags.sh`**
  Defines environment variables for server startup, including memory allocation, server name, IP and port settings, Steam integration, and admin credentials. Includes Docker-specific usage instructions for overriding variables.

### Gameplay and Server Behavior Configuration

* **`server/env/server-init-settings.sh`**
  Provides extensive configuration options for gameplay mechanics, multiplayer features, anti-cheat settings, safehouse management, and server backups. Includes detailed documentation for each variable and Docker usage instructions.

### Sandbox Variables Configuration

* **`server/Server/template_SandboxVars.lua`**
  Uses the `server_sandbox_vars.lua` template to set in-game sandbox parameters (e.g. loot distribution, zombie behavior, environmental modifiers). These values are read and applied at server startup, enabling fine-grained control over world rules. Docker users can override any sandbox setting via environment variables mapped through this script.
