### PR TITLE
feat: add Ruff linter to CI workflow

### DIFF
--- a/.config/ruff.toml
+++ b/.config/ruff.toml
@@ -8,7 +8,7 @@ exclude = [
 
 line-length   = 88
 indent-width  = 4
-target-version = ["py312"]
+target-version = "py312"
 
 [lint]
 select       = ["ALL"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
       shfmt: ${{ contains(steps.check.outputs.modified_keys, 'shfmt') }}
       eslint: ${{ contains(steps.check.outputs.modified_keys, 'eslint') }}
       prettier: ${{ contains(steps.check.outputs.modified_keys, 'prettier') }}
+      python: ${{ contains(steps.check.outputs.modified_keys, 'python') }}
     steps:
       - name: Checkout code (on push)
         if: ${{ github.event_name == 'push' }}
@@ -150,6 +151,8 @@ jobs:
               - "**/*.js"
               - "**/*.mjs"
               - "**/*.cjs"
+            python:
+              - "**/*.py"
 
   # Run yamllint on all YAML files.
   # -> Fails if there are any linting issues.
@@ -291,6 +294,31 @@ jobs:
       - name: Run prettier
         shell: bash
         run: npm run --silent ci:prettier
+
+  ruff-python:
+    name: Ruff
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs:
+      - files-changed
+    if: ${{ needs.files-changed.outputs.python == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        shell: bash
+        run: pip install --no-cache-dir ruff
+
+      - name: Run ruff linter
+        shell: bash
+        run: ruff check --config .config/ruff.toml --quiet .
 
   # Block the PR until all checks have passed.
   checks-passed:

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "ruff-fix": "ruff check --config ./.config/ruff.toml --fix --quiet .",
     "format": "prettier --config ./.config/.prettierrc.yml --ignore-path ./.config/.prettierignore --write .",
     "ci:eslint": "eslint --config ./.config/.eslint.config.mjs --max-warnings 0 --no-color --quiet .",
-    "ci:prettier": "prettier --config ./.config/.prettierrc.yml --ignore-path ./.config/.prettierignore --check --no-color .",
-    "ci:ruff": "ruff check --config ./.config/ruff.toml --quiet ."
+    "ci:prettier": "prettier --config ./.config/.prettierrc.yml --ignore-path ./.config/.prettierignore --check --no-color ."
   },
   "devDependencies": {
     "eslint": "^9.20.0",


### PR DESCRIPTION
This pull request introduces changes to streamline Python linting and configuration, as well as updates to CI workflows. The most notable updates include the addition of Ruff linter integration, modifications to the CI configuration for Python file checks, and adjustments to the `package.json` scripts.

### Python linting and configuration updates:
* [`.config/ruff.toml`](diffhunk://#diff-6639227aea5055f6a073cd889de0656f0aab3f2123535feafc506969aecdb3e0L11-R11): Changed `target-version` from a list to a single string for Python 3.12 compatibility.

### CI workflow enhancements:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR107): Added Python file detection to the CI workflow and configured Ruff linter as a separate job. This includes setting up Python 3.12, installing Ruff, and running lint checks on Python files. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR107) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR154-R155) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR298-R322)

### `package.json` updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L11-R11): Removed the `ci:ruff` script, as Ruff linting is now handled directly within the CI workflow.