### PR TITLE
refactor: rename generate templates script

### DIFF
--- a/zomboid-server/Dockerfile
+++ b/zomboid-server/Dockerfile
@@ -11,14 +11,12 @@ RUN mkdir -p /pzomboid-server \
 COPY ./scripts/build /scripts/build
 
 RUN chmod +x /scripts/build/*.sh \
-    && /scripts/build/generate-templates.sh
+    && /scripts/build/generate-defaults.sh
 
 FROM python:3.12-slim AS runtime
 
 COPY --from=build /pzomboid-server /pzomboid-server
 COPY --from=build /root/Zomboid /root/Zomboid
-
-VOLUME ["/pzomboid-server", "/root/Zomboid"]
 
 COPY ./scripts /scripts
 COPY ./env /env

--- a/zomboid-server/scripts/build/generate-defaults.sh
+++ b/zomboid-server/scripts/build/generate-defaults.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
-# generate-templates.sh - Generates the template files Project Zomboid configuration
+# generate-defaults.sh - Generates the default files Project Zomboid configuration
 #
 # This script starts the Project Zomboid server in the background to generate the
-# template configuration files, specifically the template_SandboxVars.lua file and
-# template.ini file.
+# default configuration files, specifically the servertest_SandboxVars.lua file and
+# servertest.ini file.
 #
 # It waits for up to 120 seconds for the file to be created, then stops the server.
 # If the file is not created within the timeout, it exits with an error.
 #
 # Usage:
-#   ./generate-templates.sh
+#   ./generate-defaults.sh
 #
 
 SERVER_DIR="${SERVER_DIR:-/pzomboid-server}"
@@ -26,24 +26,24 @@ cd "${SERVER_DIR}" || {
 
 chmod +x ./start-server.sh
 
-echo "Starting server in background to generate template_SandboxVars.lua..."
+echo "Starting server in background to generate servertest_SandboxVars.lua..."
 ./start-server.sh \
-	-servername template \
-	-adminpassword template \
+	-servername servertest \
+	-adminpassword default \
 	-cachedir="${CACHE_DIR}" &
 server_pid=$!
 
-echo "Waiting up to 120 seconds for file: ${CACHE_DIR}/Server/template_SandboxVars.lua"
+echo "Waiting up to 120 seconds for file: ${CACHE_DIR}/Server/servertest_SandboxVars.lua"
 start_time=${SECONDS}
 while [[ $((SECONDS - start_time)) -lt 120 ]]; do
-	if [[ -f "${CACHE_DIR}/Server/template_SandboxVars.lua" ]]; then
+	if [[ -f "${CACHE_DIR}/Server/servertest_SandboxVars.lua" ]]; then
 		break
 	fi
 	sleep 1
 done
 
-if [[ ! -f "${CACHE_DIR}/Server/template_SandboxVars.lua" ]]; then
-	echo "Error: timed out after 120 seconds waiting for template_SandboxVars.lua"
+if [[ ! -f "${CACHE_DIR}/Server/servertest_SandboxVars.lua" ]]; then
+	echo "Error: timed out after 120 seconds waiting for servertest_SandboxVars.lua"
 	kill "${server_pid}" || true
 	exit 1
 fi

--- a/zomboid-server/scripts/setup/helpers.py
+++ b/zomboid-server/scripts/setup/helpers.py
@@ -145,7 +145,7 @@ def replace_file_variables(
 
     Reads the specified file, updates lines containing variables found in
     variables_dict, and writes the updated content to a new file whose name
-    replaces 'template' with the given server_name.
+    replaces 'servertest' with the given server_name.
 
     Args:
         file_path (str): Path to the configuration file to update.
@@ -189,7 +189,7 @@ def replace_file_variables(
         else:
             new_lines.append(line)
 
-    new_file_path = file_path.replace("template", server_name)
+    new_file_path = file_path.replace("servertest", server_name)
     logger.info("Writing updated configuration to '%s'.", new_file_path)
 
     with Path(new_file_path).open("w") as file:

--- a/zomboid-server/scripts/setup/update_server_config.py
+++ b/zomboid-server/scripts/setup/update_server_config.py
@@ -21,8 +21,8 @@ if __name__ == "__main__":
     server_name = env_vars["SERVER_NAME"]
     presets_dir = env_vars["PRESETS_DIR"]
 
-    default_config_file = f"{cache_dir}/Server/template.ini"
-    default_sandbox_file = f"{cache_dir}/Server/template_SandboxVars.lua"
+    default_config_file = f"{cache_dir}/Server/servertest.ini"
+    default_sandbox_file = f"{cache_dir}/Server/servertest_SandboxVars.lua"
 
     preset_file = f"{presets_dir}/{selected_preset}.lua" if selected_preset else None
 


### PR DESCRIPTION
This pull request updates the Project Zomboid server configuration process to use "servertest" as the default naming convention instead of "template." The changes include renaming a script, updating file paths and variable replacements, and modifying related documentation and scripts.

### Updates to naming conventions:

* Renamed the script `generate-templates.sh` to `generate-defaults.sh` and updated its purpose to generate default configuration files instead of template files (`zomboid-server/scripts/build/generate-defaults.sh`).
* Updated all references to "template" in the renamed script to "servertest," including server names, file paths, and error messages (`zomboid-server/scripts/build/generate-defaults.sh`).

### Updates to file paths and variable replacements:

* Replaced "template" with "servertest" in file paths and variable replacements in the `replace_file_variables` function in `helpers.py` (`zomboid-server/scripts/setup/helpers.py`). [[1]](diffhunk://#diff-822ab384ff76188bfbfcb9d61607a6e282e6a6f10e7b38f0435270d4c62ca9b8L148-R148) [[2]](diffhunk://#diff-822ab384ff76188bfbfcb9d61607a6e282e6a6f10e7b38f0435270d4c62ca9b8L192-R192)
* Updated default configuration and sandbox file paths in `update_server_config.py` to use "servertest" instead of "template" (`zomboid-server/scripts/setup/update_server_config.py`).

### Dockerfile adjustments:

* Updated the Dockerfile to use the renamed `generate-defaults.sh` script instead of the old `generate-templates.sh` script (`zomboid-server/Dockerfile`).