### PR TITLE
fix: remove zomboid zerver compose from development env

### DIFF
--- a/.config/ruff.toml
+++ b/.config/ruff.toml
@@ -15,6 +15,8 @@ select       = ["ALL"]
 ignore       = [
   "D100",
   "INP001",
+  "ERA001",
+  "PLW2901",
 ]
 fixable      = ["ALL"]
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 
   // Run with Docker Compose.
   // https://code.visualstudio.com/docs/devcontainers/create-dev-container#_use-docker-compose
-  "dockerComposeFile": ["../docker-compose.yml", "./docker-compose.yml"],
+  "dockerComposeFile": ["./docker-compose.yml"],
   "service": "devcontainer",
   "workspaceFolder": "/workspaces/project-zomboid-server",
 


### PR DESCRIPTION
This pull request includes updates to configuration files to adjust linting rules and simplify the Docker Compose setup for the development container.

### Configuration updates:

* [`.config/ruff.toml`](diffhunk://#diff-6639227aea5055f6a073cd889de0656f0aab3f2123535feafc506969aecdb3e0R18-R19): Added `ERA001` and `PLW2901` to the `ignore` list for Ruff linting rules.

### Development container setup:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L8-R8): Simplified the `dockerComposeFile` configuration by removing the reference to `../docker-compose.yml`.  This change was made because building the server image and running it within devcontainers is not optimal, as it can take too long to build.