### PR TITLE
feat: upgrade environment vars loading mechanism

### DIFF
--- a/zomboid-server/Dockerfile
+++ b/zomboid-server/Dockerfile
@@ -17,11 +17,10 @@ FROM python:3.12-slim AS runtime
 
 COPY --from=build /pzomboid-server /pzomboid-server
 COPY --from=build /root/Zomboid /zomboid-data
+COPY --from=build /defaults /defaults
 
 COPY ./scripts /scripts
 COPY ./env /env
-
-VOLUME [ "/root/Zomboid" ]
 
 ARG RCON_CLI_VERSION=0.10.3
 ENV RCON_CLI_DOWNLOAD_URL="https://github.com/gorcon/rcon-cli/releases/download/v${RCON_CLI_VERSION}/rcon-${RCON_CLI_VERSION}-amd64_linux.tar.gz"

--- a/zomboid-server/env/server-init-flags.sh
+++ b/zomboid-server/env/server-init-flags.sh
@@ -23,6 +23,7 @@ SERVER_DIR="${SERVER_DIR:-/pzomboid-server}"
 PRESETS_DIR="${PRESETS_DIR:-${SERVER_DIR}/media/lua/shared/Sandbox}"
 ZOMBOID_APP_ID="${ZOMBOID_APP_ID:-380870}"
 SERVER_PRESET="${SERVER_PRESET:-}"
+DEFAULTS_DIR="${DEFAULTS_DIR:-/defaults}"
 
 # Java and memory settings
 SERVER_MEMORY="${SERVER_MEMORY:-2048m}"

--- a/zomboid-server/env/server-init-settings.sh
+++ b/zomboid-server/env/server-init-settings.sh
@@ -33,417 +33,417 @@
 set -a
 
 # Players can hurt and kill other players
-PVP="${PVP:-true}"
+PVP="${PVP:-not-custom-set}"
 
 # Game time stops when there are no players online
-PAUSE_EMPTY="${PAUSE_EMPTY:-true}"
+PAUSE_EMPTY="${PAUSE_EMPTY:-not-custom-set}"
 
 # Toggles global chat on or off.
-GLOBAL_CHAT="${GLOBAL_CHAT:-true}"
+GLOBAL_CHAT="${GLOBAL_CHAT:-not-custom-set}"
 
 # Chat streams available to players
-CHAT_STREAMS="${CHAT_STREAMS:-"s,r,a,w,y,sh,f,all"}"
+CHAT_STREAMS="${CHAT_STREAMS:-not-custom-set}"
 
 # Clients may join without already having an account in the whitelist. If set to false, administrators must manually create username/password combos.
-OPEN="${OPEN:-true}"
+OPEN="${OPEN:-not-custom-set}"
 
 # The first welcome message visible in the chat panel. This will be displayed immediately after player login.
-SERVER_WELCOME_MESSAGE="${SERVER_WELCOME_MESSAGE:-"Welcome to Project Zomboid Multiplayer! <LINE> <LINE> To interact with the Chat panel: press Tab, T, or Enter. <LINE> <LINE> The Tab key will change the target stream of the message. <LINE> <LINE> Global Streams: /all <LINE> Local Streams: /say, /yell <LINE> Special Steams: /whisper, /safehouse, /faction. <LINE> <LINE> Press the Up arrow to cycle through your message history. Click the Gear icon to customize chat. <LINE> <LINE> Happy surviving!"}"
+SERVER_WELCOME_MESSAGE="${SERVER_WELCOME_MESSAGE:-not-custom-set}"
 
 # Add unknown usernames to the whitelist when players join. Clients will supply their own username/password on joining. (This is for Open=true servers)
-AUTO_CREATE_USER_IN_WHITE_LIST="${AUTO_CREATE_USER_IN_WHITE_LIST:-false}"
+AUTO_CREATE_USER_IN_WHITE_LIST="${AUTO_CREATE_USER_IN_WHITE_LIST:-not-custom-set}"
 
 # Display usernames above player's heads in-game.
-DISPLAY_USER_NAME="${DISPLAY_USER_NAME:-true}"
+DISPLAY_USER_NAME="${DISPLAY_USER_NAME:-not-custom-set}"
 
 # Display first & last name above player's heads.
-SHOW_FIRST_AND_LAST_NAME="${SHOW_FIRST_AND_LAST_NAME:-false}"
+SHOW_FIRST_AND_LAST_NAME="${SHOW_FIRST_AND_LAST_NAME:-not-custom-set}"
 
 # Force every new player to spawn at these set x,y,z world coordinates. (Ignored when 0,0,0)
-SPAWN_POINT="${SPAWN_POINT:-"0,0,0"}"
+SPAWN_POINT="${SPAWN_POINT:-not-custom-set}"
 
 # Players can enter and leave PVP on an individual basis. When SafetySystem=false, players are free to hurt each other at any time if PVP is enabled.
-SAFETY_SYSTEM="${SAFETY_SYSTEM:-true}"
+SAFETY_SYSTEM="${SAFETY_SYSTEM:-not-custom-set}"
 
 # Display a skull icon over the head of players who have entered PVP mode
-SHOW_SAFETY="${SHOW_SAFETY:-true}"
+SHOW_SAFETY="${SHOW_SAFETY:-not-custom-set}"
 
 # The time it takes for a player to enter and leave PVP mode
-SAFETY_TOGGLE_TIMER="${SAFETY_TOGGLE_TIMER:-2}"
+SAFETY_TOGGLE_TIMER="${SAFETY_TOGGLE_TIMER:-not-custom-set}"
 
 # The delay before a player can enter or leave PVP mode again, having recently done so
-SAFETY_COOLDOWN_TIMER="${SAFETY_COOLDOWN_TIMER:-3}"
+SAFETY_COOLDOWN_TIMER="${SAFETY_COOLDOWN_TIMER:-not-custom-set}"
 
 # Item types new players spawn with. Separate multiple item types with commas.
-SPAWN_ITEMS="${SPAWN_ITEMS:-}"
+SPAWN_ITEMS="${SPAWN_ITEMS:-not-custom-set}"
 
 # Default starting port for player data. If UDP, this is this one of two ports used.
-DEFAULT_PORT="${DEFAULT_PORT:-16261}"
+DEFAULT_PORT="${DEFAULT_PORT:-not-custom-set}"
 
 # UDP port for server communication
-UDP_PORT="${UDP_PORT:-16262}"
+UDP_PORT="${UDP_PORT:-not-custom-set}"
 
 # Reset ID determines if the server has undergone a soft-reset. If this number does match the client, the client must create a new character.
-RESET_ID="${RESET_ID:-8267201}"
+RESET_ID="${RESET_ID:-not-custom-set}"
 
 # Enter the mod loading ID here. It can be found in \Steam\steamapps\workshop\modID\mods\modName\info.txt
-MODS="${MODS:-}"
+MODS="${MODS:-not-custom-set}"
 
 # Enter the foldername of the mod found in \Steam\steamapps\workshop\modID\mods\modName\media\maps\
-MAP="${MAP:-"Muldraugh, KY"}"
+MAP="${MAP:-not-custom-set}"
 
 # Kick clients whose game files don't match the server's.
-DO_LUA_CHECKSUM="${DO_LUA_CHECKSUM:-true}"
+DO_LUA_CHECKSUM="${DO_LUA_CHECKSUM:-not-custom-set}"
 
 # Deny login if the server is overloaded
-DENY_LOGIN_ON_OVERLOADED_SERVER="${DENY_LOGIN_ON_OVERLOADED_SERVER:-true}"
+DENY_LOGIN_ON_OVERLOADED_SERVER="${DENY_LOGIN_ON_OVERLOADED_SERVER:-not-custom-set}"
 
 # Shows the server on the in-game browser. (Note: Steam-enabled servers are always visible in the Steam server browser)
-PUBLIC="${PUBLIC:-false}"
+PUBLIC="${PUBLIC:-not-custom-set}"
 
 # Name of the server displayed in the in-game browser and, if applicable, the Steam browser
-PUBLIC_NAME="${PUBLIC_NAME:-"My PZ Server"}"
+PUBLIC_NAME="${PUBLIC_NAME:-not-custom-set}"
 
 # Description displayed in the in-game public server browser. Typing \n will create a new line in your description
-PUBLIC_DESCRIPTION="${PUBLIC_DESCRIPTION:-}"
+PUBLIC_DESCRIPTION="${PUBLIC_DESCRIPTION:-not-custom-set}"
 
 # Maximum number of players that can be on the server at one time. This excludes admins.
-MAX_PLAYERS="${MAX_PLAYERS:-32}"
+MAX_PLAYERS="${MAX_PLAYERS:-not-custom-set}"
 
 # Ping limit, in milliseconds, before a player is kicked from the server. (Set to 100 to disable)
-PING_LIMIT="${PING_LIMIT:-400}"
+PING_LIMIT="${PING_LIMIT:-not-custom-set}"
 
 # After X hours, all containers in the world will respawn loot. To spawn loot a container must have been looted at least once.
-HOURS_FOR_LOOT_RESPAWN="${HOURS_FOR_LOOT_RESPAWN:-0}"
+HOURS_FOR_LOOT_RESPAWN="${HOURS_FOR_LOOT_RESPAWN:-not-custom-set}"
 
 # Containers with a number of items greater, or equal to, this setting will not respawn
-MAX_ITEMS_FOR_LOOT_RESPAWN="${MAX_ITEMS_FOR_LOOT_RESPAWN:-4}"
+MAX_ITEMS_FOR_LOOT_RESPAWN="${MAX_ITEMS_FOR_LOOT_RESPAWN:-not-custom-set}"
 
 # Items will not respawn in buildings that players have barricaded or built in
-CONSTRUCTION_PREVENTS_LOOT_RESPAWN="${CONSTRUCTION_PREVENTS_LOOT_RESPAWN:-true}"
+CONSTRUCTION_PREVENTS_LOOT_RESPAWN="${CONSTRUCTION_PREVENTS_LOOT_RESPAWN:-not-custom-set}"
 
 # Remove player accounts from the whitelist after death. This prevents players creating a new character after death on Open=false servers
-DROP_OFF_WHITE_LIST_AFTER_DEATH="${DROP_OFF_WHITE_LIST_AFTER_DEATH:-false}"
+DROP_OFF_WHITE_LIST_AFTER_DEATH="${DROP_OFF_WHITE_LIST_AFTER_DEATH:-not-custom-set}"
 
 # All forms of fire are disabled - except for campfires
-NO_FIRE="${NO_FIRE:-false}"
+NO_FIRE="${NO_FIRE:-not-custom-set}"
 
 # If checked, every time a player dies a global message will be displayed in the chat
-ANNOUNCE_DEATH="${ANNOUNCE_DEATH:-false}"
+ANNOUNCE_DEATH="${ANNOUNCE_DEATH:-not-custom-set}"
 
 # The number of in-game minutes it takes to read one page of a book
-MINUTES_PER_PAGE="${MINUTES_PER_PAGE:-1.0}"
+MINUTES_PER_PAGE="${MINUTES_PER_PAGE:-not-custom-set}"
 
 # Loaded parts of the map are saved after this set number of real-world minutes have passed.
-SAVE_WORLD_EVERY_MINUTES="${SAVE_WORLD_EVERY_MINUTES:-0}"
+SAVE_WORLD_EVERY_MINUTES="${SAVE_WORLD_EVERY_MINUTES:-not-custom-set}"
 
 # Both admins and players can claim safehouses
-PLAYER_SAFEHOUSE="${PLAYER_SAFEHOUSE:-false}"
+PLAYER_SAFEHOUSE="${PLAYER_SAFEHOUSE:-not-custom-set}"
 
 # Only admins can claim safehouses
-ADMIN_SAFEHOUSE="${ADMIN_SAFEHOUSE:-false}"
+ADMIN_SAFEHOUSE="${ADMIN_SAFEHOUSE:-not-custom-set}"
 
 # Allow non-members to enter a safehouse without being invited
-SAFEHOUSE_ALLOW_TREPASS="${SAFEHOUSE_ALLOW_TREPASS:-true}"
+SAFEHOUSE_ALLOW_TREPASS="${SAFEHOUSE_ALLOW_TREPASS:-not-custom-set}"
 
 # Allow fire to damage safehouses
-SAFEHOUSE_ALLOW_FIRE="${SAFEHOUSE_ALLOW_FIRE:-true}"
+SAFEHOUSE_ALLOW_FIRE="${SAFEHOUSE_ALLOW_FIRE:-not-custom-set}"
 
 # Allow non-members to take items from safehouses
-SAFEHOUSE_ALLOW_LOOT="${SAFEHOUSE_ALLOW_LOOT:-true}"
+SAFEHOUSE_ALLOW_LOOT="${SAFEHOUSE_ALLOW_LOOT:-not-custom-set}"
 
 # Players will respawn in a safehouse that they were a member of before they died
-SAFEHOUSE_ALLOW_RESPAWN="${SAFEHOUSE_ALLOW_RESPAWN:-false}"
+SAFEHOUSE_ALLOW_RESPAWN="${SAFEHOUSE_ALLOW_RESPAWN:-not-custom-set}"
 
 # Players must have survived this number of in-game days before they are allowed to claim a safehouse
-SAFEHOUSE_DAY_SURVIVED_TO_CLAIM="${SAFEHOUSE_DAY_SURVIVED_TO_CLAIM:-0}"
+SAFEHOUSE_DAY_SURVIVED_TO_CLAIM="${SAFEHOUSE_DAY_SURVIVED_TO_CLAIM:-not-custom-set}"
 
 # Players are automatically removed from a safehouse they have not visited for this many real-world hours
-SAFE_HOUSE_REMOVAL_TIME="${SAFE_HOUSE_REMOVAL_TIME:-144}"
+SAFE_HOUSE_REMOVAL_TIME="${SAFE_HOUSE_REMOVAL_TIME:-not-custom-set}"
 
 # Governs whether players can claim non-residential buildings.
-SAFEHOUSE_ALLOW_NON_RESIDENTIAL="${SAFEHOUSE_ALLOW_NON_RESIDENTIAL:-false}"
+SAFEHOUSE_ALLOW_NON_RESIDENTIAL="${SAFEHOUSE_ALLOW_NON_RESIDENTIAL:-not-custom-set}"
 
 # Allow players to destroy world objects with sledgehammers
-ALLOW_DESTRUCTION_BY_SLEDGEHAMMER="${ALLOW_DESTRUCTION_BY_SLEDGEHAMMER:-true}"
+ALLOW_DESTRUCTION_BY_SLEDGEHAMMER="${ALLOW_DESTRUCTION_BY_SLEDGEHAMMER:-not-custom-set}"
 
 # Allow players to destroy world objects only in their safehouse (require AllowDestructionBySledgehammer to true).
-SLEDGEHAMMER_ONLY_IN_SAFEHOUSE="${SLEDGEHAMMER_ONLY_IN_SAFEHOUSE:-false}"
+SLEDGEHAMMER_ONLY_IN_SAFEHOUSE="${SLEDGEHAMMER_ONLY_IN_SAFEHOUSE:-not-custom-set}"
 
 # Kick players that appear to be moving faster than is possible. May be buggy -- use with caution.
-KICK_FAST_PLAYERS="${KICK_FAST_PLAYERS:-false}"
+KICK_FAST_PLAYERS="${KICK_FAST_PLAYERS:-not-custom-set}"
 
 # ServerPlayerID determines if a character is from another server, or single player. This value may be changed by soft resets.
-SERVER_PLAYER_ID="${SERVER_PLAYER_ID:-934857515}"
+SERVER_PLAYER_ID="${SERVER_PLAYER_ID:-not-custom-set}"
 
 # The port for the RCON (Remote Console)
-RCON_PORT="${RCON_PORT:-27015}"
+RCON_PORT="${RCON_PORT:-not-custom-set}"
 
 # RCON password (Pick a strong password)
-RCON_PASSWORD="${RCON_PASSWORD:-admin}"
+RCON_PASSWORD="${RCON_PASSWORD:-not-custom-set}"
 
 # Enables global text chat integration with a Discord channel
-DISCORD_ENABLE="${DISCORD_ENABLE:-false}"
+DISCORD_ENABLE="${DISCORD_ENABLE:-not-custom-set}"
 
 # Discord bot access token
-DISCORD_TOKEN="${DISCORD_TOKEN:-}"
+DISCORD_TOKEN="${DISCORD_TOKEN:-not-custom-set}"
 
 # The Discord channel name. (Try the separate channel ID option if having difficulties)
-DISCORD_CHANNEL="${DISCORD_CHANNEL:-}"
+DISCORD_CHANNEL="${DISCORD_CHANNEL:-not-custom-set}"
 
 # The Discord channel ID. (Use if having difficulties with Discord channel name option)
-DISCORD_CHANNEL_ID="${DISCORD_CHANNEL_ID:-}"
+DISCORD_CHANNEL_ID="${DISCORD_CHANNEL_ID:-not-custom-set}"
 
 # Clients must know this password to join the server. (Ignored when hosting a server via the Host button)
-PASSWORD="${PASSWORD:-}"
+PASSWORD="${PASSWORD:-not-custom-set}"
 
 # Limits the number of different accounts a single Steam user may create on this server. Ignored when using the Hosts button.
-MAX_ACCOUNTS_PER_USER="${MAX_ACCOUNTS_PER_USER:-0}"
+MAX_ACCOUNTS_PER_USER="${MAX_ACCOUNTS_PER_USER:-not-custom-set}"
 
 # Allow co-op/splitscreen players
-ALLOW_COOP="${ALLOW_COOP:-true}"
+ALLOW_COOP="${ALLOW_COOP:-not-custom-set}"
 
 # Players are allowed to sleep when their survivor becomes tired, but they do not NEED to sleep
-SLEEP_ALLOWED="${SLEEP_ALLOWED:-false}"
+SLEEP_ALLOWED="${SLEEP_ALLOWED:-not-custom-set}"
 
 # Players get tired and need to sleep. (Ignored if SleepAllowed=false)
-SLEEP_NEEDED="${SLEEP_NEEDED:-false}"
+SLEEP_NEEDED="${SLEEP_NEEDED:-not-custom-set}"
 
 # If true, players can be knocked down
-KNOCKED_DOWN_ALLOWED="${KNOCKED_DOWN_ALLOWED:-true}"
+KNOCKED_DOWN_ALLOWED="${KNOCKED_DOWN_ALLOWED:-not-custom-set}"
 
 # If true, sneaking players are hidden from others
-SNEAK_MODE_HIDE_FROM_OTHER_PLAYERS="${SNEAK_MODE_HIDE_FROM_OTHER_PLAYERS:-true}"
+SNEAK_MODE_HIDE_FROM_OTHER_PLAYERS="${SNEAK_MODE_HIDE_FROM_OTHER_PLAYERS:-not-custom-set}"
 
 # List Workshop Mod IDs for the server to download. Each must be separated by a semicolon.
-WORKSHOP_ITEMS="${WORKSHOP_ITEMS:-}"
+WORKSHOP_ITEMS="${WORKSHOP_ITEMS:-not-custom-set}"
 
 # Show Steam usernames and avatars in the Players list. Can be true (visible to everyone), false (visible to no one), or admin (visible to only admins)
-STEAM_SCOREBOARD="${STEAM_SCOREBOARD:-true}"
+STEAM_SCOREBOARD="${STEAM_SCOREBOARD:-not-custom-set}"
 
 # Attempt to configure a UPnP-enabled internet gateway to automatically setup port forwarding rules.
-UPNP="${UPNP:-true}"
+UPNP="${UPNP:-not-custom-set}"
 
 # VOIP is enabled when checked
-VOICE_ENABLE="${VOICE_ENABLE:-true}"
+VOICE_ENABLE="${VOICE_ENABLE:-not-custom-set}"
 
 # The minimum tile distance over which VOIP sounds can be heard.
-VOICE_MIN_DISTANCE="${VOICE_MIN_DISTANCE:-10.0}"
+VOICE_MIN_DISTANCE="${VOICE_MIN_DISTANCE:-not-custom-set}"
 
 # The maximum tile distance over which VOIP sounds can be heard.
-VOICE_MAX_DISTANCE="${VOICE_MAX_DISTANCE:-100.0}"
+VOICE_MAX_DISTANCE="${VOICE_MAX_DISTANCE:-not-custom-set}"
 
 # Toggle directional audio for VOIP
-VOICE_3D="${VOICE_3D:-true}"
+VOICE_3D="${VOICE_3D:-not-custom-set}"
 
 # Maximum speed limit for vehicles
-SPEED_LIMIT="${SPEED_LIMIT:-70.0}"
+SPEED_LIMIT="${SPEED_LIMIT:-not-custom-set}"
 
 # Enable login queue for server
-LOGIN_QUEUE_ENABLED="${LOGIN_QUEUE_ENABLED:-false}"
+LOGIN_QUEUE_ENABLED="${LOGIN_QUEUE_ENABLED:-not-custom-set}"
 
 # Timeout for login queue connection
-LOGIN_QUEUE_CONNECT_TIMEOUT="${LOGIN_QUEUE_CONNECT_TIMEOUT:-60}"
+LOGIN_QUEUE_CONNECT_TIMEOUT="${LOGIN_QUEUE_CONNECT_TIMEOUT:-not-custom-set}"
 
 # Set the IP from which the server is broadcast. This is for network configurations with multiple IP addresses, such as server farms
-SERVER_BROWSER_ANNOUNCED_IP="${SERVER_BROWSER_ANNOUNCED_IP:-}"
+SERVER_BROWSER_ANNOUNCED_IP="${SERVER_BROWSER_ANNOUNCED_IP:-not-custom-set}"
 
 # Players can respawn in-game at the coordinates where they died
-PLAYER_RESPAWN_WITH_SELF="${PLAYER_RESPAWN_WITH_SELF:-false}"
+PLAYER_RESPAWN_WITH_SELF="${PLAYER_RESPAWN_WITH_SELF:-not-custom-set}"
 
 # Players can respawn in-game at a split screen / Remote Play player's location
-PLAYER_RESPAWN_WITH_OTHER="${PLAYER_RESPAWN_WITH_OTHER:-false}"
+PLAYER_RESPAWN_WITH_OTHER="${PLAYER_RESPAWN_WITH_OTHER:-not-custom-set}"
 
 # Governs how fast time passes while players sleep. Value multiplies the speed of the time that passes during sleeping.
-FAST_FORWARD_MULTIPLIER="${FAST_FORWARD_MULTIPLIER:-40.0}"
+FAST_FORWARD_MULTIPLIER="${FAST_FORWARD_MULTIPLIER:-not-custom-set}"
 
 # Safehouse acts like a normal house if a member of the safehouse is connected (so secure when players are offline)
-DISABLE_SAFEHOUSE_WHEN_PLAYER_CONNECTED="${DISABLE_SAFEHOUSE_WHEN_PLAYER_CONNECTED:-false}"
+DISABLE_SAFEHOUSE_WHEN_PLAYER_CONNECTED="${DISABLE_SAFEHOUSE_WHEN_PLAYER_CONNECTED:-not-custom-set}"
 
 # Players can create factions when true
-FACTION="${FACTION:-true}"
+FACTION="${FACTION:-not-custom-set}"
 
 # Players must survive this number of in-game days before being allowed to create a faction
-FACTION_DAY_SURVIVED_TO_CREATE="${FACTION_DAY_SURVIVED_TO_CREATE:-0}"
+FACTION_DAY_SURVIVED_TO_CREATE="${FACTION_DAY_SURVIVED_TO_CREATE:-not-custom-set}"
 
 # Number of players required as faction members before the faction owner can create a group tag
-FACTION_PLAYERS_REQUIRED_FOR_TAG="${FACTION_PLAYERS_REQUIRED_FOR_TAG:-1}"
+FACTION_PLAYERS_REQUIRED_FOR_TAG="${FACTION_PLAYERS_REQUIRED_FOR_TAG:-not-custom-set}"
 
 # Disables radio transmissions from players with an access level
-DISABLE_RADIO_STAFF="${DISABLE_RADIO_STAFF:-false}"
+DISABLE_RADIO_STAFF="${DISABLE_RADIO_STAFF:-not-custom-set}"
 
 # Disables radio transmissions from players with 'admin' access level
-DISABLE_RADIO_ADMIN="${DISABLE_RADIO_ADMIN:-true}"
+DISABLE_RADIO_ADMIN="${DISABLE_RADIO_ADMIN:-not-custom-set}"
 
 # Disables radio transmissions from players with 'gm' access level
-DISABLE_RADIO_GM="${DISABLE_RADIO_GM:-true}"
+DISABLE_RADIO_GM="${DISABLE_RADIO_GM:-not-custom-set}"
 
 # Disables radio transmissions from players with 'overseer' access level
-DISABLE_RADIO_OVERSEER="${DISABLE_RADIO_OVERSEER:-false}"
+DISABLE_RADIO_OVERSEER="${DISABLE_RADIO_OVERSEER:-not-custom-set}"
 
 # Disables radio transmissions from players with 'moderator' access level
-DISABLE_RADIO_MODERATOR="${DISABLE_RADIO_MODERATOR:-false}"
+DISABLE_RADIO_MODERATOR="${DISABLE_RADIO_MODERATOR:-not-custom-set}"
 
 # Disables radio transmissions from invisible players
-DISABLE_RADIO_INVISIBLE="${DISABLE_RADIO_INVISIBLE:-true}"
+DISABLE_RADIO_INVISIBLE="${DISABLE_RADIO_INVISIBLE:-not-custom-set}"
 
 # Semicolon-separated list of commands that will not be written to the cmd.txt server log.
-CLIENT_COMMAND_FILTER="${CLIENT_COMMAND_FILTER:-"-vehicle.*;+vehicle.damageWindow;+vehicle.fixPart;+vehicle.installPart;+vehicle.uninstallPart"}"
+CLIENT_COMMAND_FILTER="${CLIENT_COMMAND_FILTER:-not-custom-set}"
 
 # Semicolon-separated list of actions that will be written to the ClientActionLogs.txt server log.
-CLIENT_ACTION_LOGS="${CLIENT_ACTION_LOGS:-"ISEnterVehicle;ISExitVehicle;ISTakeEngineParts;"}"
+CLIENT_ACTION_LOGS="${CLIENT_ACTION_LOGS:-not-custom-set}"
 
 # Track changes in player perk levels in PerkLog.txt server log
-PERK_LOGS="${PERK_LOGS:-true}"
+PERK_LOGS="${PERK_LOGS:-not-custom-set}"
 
 # Maximum number of items that can be placed in a container. Zero means there is no limit.
-ITEM_NUMBERS_LIMIT_PER_CONTAINER="${ITEM_NUMBERS_LIMIT_PER_CONTAINER:-0}"
+ITEM_NUMBERS_LIMIT_PER_CONTAINER="${ITEM_NUMBERS_LIMIT_PER_CONTAINER:-not-custom-set}"
 
 # Number of days before old blood splats are removed. Zero means they will never disappear.
-BLOOD_SPLAT_LIFESPAN_DAYS="${BLOOD_SPLAT_LIFESPAN_DAYS:-0}"
+BLOOD_SPLAT_LIFESPAN_DAYS="${BLOOD_SPLAT_LIFESPAN_DAYS:-not-custom-set}"
 
 # Allow use of non-ASCII (cyrillic etc) characters in usernames
-ALLOW_NON_ASCII_USERNAME="${ALLOW_NON_ASCII_USERNAME:-false}"
+ALLOW_NON_ASCII_USERNAME="${ALLOW_NON_ASCII_USERNAME:-not-custom-set}"
 
-BAN_KICK_GLOBAL_SOUND="${BAN_KICK_GLOBAL_SOUND:-true}"
+BAN_KICK_GLOBAL_SOUND="${BAN_KICK_GLOBAL_SOUND:-not-custom-set}"
 
 # If enabled, when HoursForCorpseRemoval triggers, it will also remove player’s corpses from the ground.
-REMOVE_PLAYER_CORPSES_ON_CORPSE_REMOVAL="${REMOVE_PLAYER_CORPSES_ON_CORPSE_REMOVAL:-false}"
+REMOVE_PLAYER_CORPSES_ON_CORPSE_REMOVAL="${REMOVE_PLAYER_CORPSES_ON_CORPSE_REMOVAL:-not-custom-set}"
 
 # If true, player can use the "delete all" button on bins.
-TRASH_DELETE_ALL="${TRASH_DELETE_ALL:-false}"
+TRASH_DELETE_ALL="${TRASH_DELETE_ALL:-not-custom-set}"
 
 # If true, player can hit again when struck by another player.
-PVP_MELEE_WHILE_HIT_REACTION="${PVP_MELEE_WHILE_HIT_REACTION:-false}"
+PVP_MELEE_WHILE_HIT_REACTION="${PVP_MELEE_WHILE_HIT_REACTION:-not-custom-set}"
 
 # If true, players will have to mouse over someone to see their display name.
-MOUSE_OVER_TO_SEE_DISPLAY_NAME="${MOUSE_OVER_TO_SEE_DISPLAY_NAME:-true}"
+MOUSE_OVER_TO_SEE_DISPLAY_NAME="${MOUSE_OVER_TO_SEE_DISPLAY_NAME:-not-custom-set}"
 
 # If true, automatically hide the player you can't see (like zombies).
-HIDE_PLAYERS_BEHIND_YOU="${HIDE_PLAYERS_BEHIND_YOU:-true}"
+HIDE_PLAYERS_BEHIND_YOU="${HIDE_PLAYERS_BEHIND_YOU:-not-custom-set}"
 
 # Damage multiplier for PVP melee attacks.
-PVP_MELEE_DAMAGE_MODIFIER="${PVP_MELEE_DAMAGE_MODIFIER:-30.0}"
+PVP_MELEE_DAMAGE_MODIFIER="${PVP_MELEE_DAMAGE_MODIFIER:-not-custom-set}"
 
 # Damage multiplier for PVP ranged attacks.
-PVP_FIREARM_DAMAGE_MODIFIER="${PVP_FIREARM_DAMAGE_MODIFIER:-50.0}"
+PVP_FIREARM_DAMAGE_MODIFIER="${PVP_FIREARM_DAMAGE_MODIFIER:-not-custom-set}"
 
 # Modify the range of zombie attraction to cars. (Lower values can help with lag.)
-CAR_ENGINE_ATTRACTION_MODIFIER="${CAR_ENGINE_ATTRACTION_MODIFIER:-0.5}"
+CAR_ENGINE_ATTRACTION_MODIFIER="${CAR_ENGINE_ATTRACTION_MODIFIER:-not-custom-set}"
 
 # Governs whether players bump (and knock over) other players when running through them.
-PLAYER_BUMP_PLAYER="${PLAYER_BUMP_PLAYER:-false}"
+PLAYER_BUMP_PLAYER="${PLAYER_BUMP_PLAYER:-not-custom-set}"
 
 # Controls display of remote players on the in-game map. 1=Hidden 2=Friends 3=Everyone
-MAP_REMOTE_PLAYER_VISIBILITY="${MAP_REMOTE_PLAYER_VISIBILITY:-1}"
+MAP_REMOTE_PLAYER_VISIBILITY="${MAP_REMOTE_PLAYER_VISIBILITY:-not-custom-set}"
 
 # Number of backups to keep
-BACKUPS_COUNT="${BACKUPS_COUNT:-5}"
+BACKUPS_COUNT="${BACKUPS_COUNT:-not-custom-set}"
 
 # Enable backups on server start
-BACKUPS_ON_START="${BACKUPS_ON_START:-true}"
+BACKUPS_ON_START="${BACKUPS_ON_START:-not-custom-set}"
 
 # Enable backups on version change
-BACKUPS_ON_VERSION_CHANGE="${BACKUPS_ON_VERSION_CHANGE:-true}"
+BACKUPS_ON_VERSION_CHANGE="${BACKUPS_ON_VERSION_CHANGE:-not-custom-set}"
 
 # Period between backups
-BACKUPS_PERIOD="${BACKUPS_PERIOD:-0}"
+BACKUPS_PERIOD="${BACKUPS_PERIOD:-not-custom-set}"
 
 # Disables anti-cheat protection for type 1.
-ANTI_CHEAT_PROTECTION_TYPE_1="${ANTI_CHEAT_PROTECTION_TYPE_1:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_1="${ANTI_CHEAT_PROTECTION_TYPE_1:-not-custom-set}"
 
 # Disables anti-cheat protection for type 2.
-ANTI_CHEAT_PROTECTION_TYPE_2="${ANTI_CHEAT_PROTECTION_TYPE_2:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_2="${ANTI_CHEAT_PROTECTION_TYPE_2:-not-custom-set}"
 
 # Disables anti-cheat protection for type 3.
-ANTI_CHEAT_PROTECTION_TYPE_3="${ANTI_CHEAT_PROTECTION_TYPE_3:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_3="${ANTI_CHEAT_PROTECTION_TYPE_3:-not-custom-set}"
 
 # Disables anti-cheat protection for type 4.
-ANTI_CHEAT_PROTECTION_TYPE_4="${ANTI_CHEAT_PROTECTION_TYPE_4:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_4="${ANTI_CHEAT_PROTECTION_TYPE_4:-not-custom-set}"
 
 # Disables anti-cheat protection for type 5.
-ANTI_CHEAT_PROTECTION_TYPE_5="${ANTI_CHEAT_PROTECTION_TYPE_5:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_5="${ANTI_CHEAT_PROTECTION_TYPE_5:-not-custom-set}"
 
 # Disables anti-cheat protection for type 6.
-ANTI_CHEAT_PROTECTION_TYPE_6="${ANTI_CHEAT_PROTECTION_TYPE_6:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_6="${ANTI_CHEAT_PROTECTION_TYPE_6:-not-custom-set}"
 
 # Disables anti-cheat protection for type 7.
-ANTI_CHEAT_PROTECTION_TYPE_7="${ANTI_CHEAT_PROTECTION_TYPE_7:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_7="${ANTI_CHEAT_PROTECTION_TYPE_7:-not-custom-set}"
 
 # Disables anti-cheat protection for type 8.
-ANTI_CHEAT_PROTECTION_TYPE_8="${ANTI_CHEAT_PROTECTION_TYPE_8:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_8="${ANTI_CHEAT_PROTECTION_TYPE_8:-not-custom-set}"
 
 # Disables anti-cheat protection for type 9.
-ANTI_CHEAT_PROTECTION_TYPE_9="${ANTI_CHEAT_PROTECTION_TYPE_9:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_9="${ANTI_CHEAT_PROTECTION_TYPE_9:-not-custom-set}"
 
 # Disables anti-cheat protection for type 10.
-ANTI_CHEAT_PROTECTION_TYPE_10="${ANTI_CHEAT_PROTECTION_TYPE_10:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_10="${ANTI_CHEAT_PROTECTION_TYPE_10:-not-custom-set}"
 
 # Disables anti-cheat protection for type 11.
-ANTI_CHEAT_PROTECTION_TYPE_11="${ANTI_CHEAT_PROTECTION_TYPE_11:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_11="${ANTI_CHEAT_PROTECTION_TYPE_11:-not-custom-set}"
 
 # Disables anti-cheat protection for type 12.
-ANTI_CHEAT_PROTECTION_TYPE_12="${ANTI_CHEAT_PROTECTION_TYPE_12:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_12="${ANTI_CHEAT_PROTECTION_TYPE_12:-not-custom-set}"
 
 # Disables anti-cheat protection for type 13.
-ANTI_CHEAT_PROTECTION_TYPE_13="${ANTI_CHEAT_PROTECTION_TYPE_13:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_13="${ANTI_CHEAT_PROTECTION_TYPE_13:-not-custom-set}"
 
 # Disables anti-cheat protection for type 14.
-ANTI_CHEAT_PROTECTION_TYPE_14="${ANTI_CHEAT_PROTECTION_TYPE_14:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_14="${ANTI_CHEAT_PROTECTION_TYPE_14:-not-custom-set}"
 
 # Disables anti-cheat protection for type 15.
-ANTI_CHEAT_PROTECTION_TYPE_15="${ANTI_CHEAT_PROTECTION_TYPE_15:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_15="${ANTI_CHEAT_PROTECTION_TYPE_15:-not-custom-set}"
 
 # Disables anti-cheat protection for type 16.
-ANTI_CHEAT_PROTECTION_TYPE_16="${ANTI_CHEAT_PROTECTION_TYPE_16:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_16="${ANTI_CHEAT_PROTECTION_TYPE_16:-not-custom-set}"
 
 # Disables anti-cheat protection for type 17.
-ANTI_CHEAT_PROTECTION_TYPE_17="${ANTI_CHEAT_PROTECTION_TYPE_17:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_17="${ANTI_CHEAT_PROTECTION_TYPE_17:-not-custom-set}"
 
 # Disables anti-cheat protection for type 18.
-ANTI_CHEAT_PROTECTION_TYPE_18="${ANTI_CHEAT_PROTECTION_TYPE_18:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_18="${ANTI_CHEAT_PROTECTION_TYPE_18:-not-custom-set}"
 
 # Disables anti-cheat protection for type 19.
-ANTI_CHEAT_PROTECTION_TYPE_19="${ANTI_CHEAT_PROTECTION_TYPE_19:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_19="${ANTI_CHEAT_PROTECTION_TYPE_19:-not-custom-set}"
 
 # Disables anti-cheat protection for type 20.
-ANTI_CHEAT_PROTECTION_TYPE_20="${ANTI_CHEAT_PROTECTION_TYPE_20:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_20="${ANTI_CHEAT_PROTECTION_TYPE_20:-not-custom-set}"
 
 # Disables anti-cheat protection for type 21.
-ANTI_CHEAT_PROTECTION_TYPE_21="${ANTI_CHEAT_PROTECTION_TYPE_21:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_21="${ANTI_CHEAT_PROTECTION_TYPE_21:-not-custom-set}"
 
 # Disables anti-cheat protection for type 22.
-ANTI_CHEAT_PROTECTION_TYPE_22="${ANTI_CHEAT_PROTECTION_TYPE_22:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_22="${ANTI_CHEAT_PROTECTION_TYPE_22:-not-custom-set}"
 
 # Disables anti-cheat protection for type 23.
-ANTI_CHEAT_PROTECTION_TYPE_23="${ANTI_CHEAT_PROTECTION_TYPE_23:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_23="${ANTI_CHEAT_PROTECTION_TYPE_23:-not-custom-set}"
 
 # Disables anti-cheat protection for type 24.
-ANTI_CHEAT_PROTECTION_TYPE_24="${ANTI_CHEAT_PROTECTION_TYPE_24:-true}"
+ANTI_CHEAT_PROTECTION_TYPE_24="${ANTI_CHEAT_PROTECTION_TYPE_24:-not-custom-set}"
 
-# Threshold value multiplier for anti-cheat protection: type 2.
-ANTI_CHEAT_PROTECTION_TYPE_2_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_2_THRESHOLD_MULTIPLIER:-3.0}"
+# Threshold value multiplier for anti-cheat protection: type 2. Minimum=1.00 Maximum=10.00
+ANTI_CHEAT_PROTECTION_TYPE_2_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_2_THRESHOLD_MULTIPLIER:-not-custom-set}"
 
-# Threshold value multiplier for anti-cheat protection: type 3.
-ANTI_CHEAT_PROTECTION_TYPE_3_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_3_THRESHOLD_MULTIPLIER:-1.0}"
+# Threshold value multiplier for anti-cheat protection: type 3. Minimum=1.00 Maximum=10.00
+ANTI_CHEAT_PROTECTION_TYPE_3_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_3_THRESHOLD_MULTIPLIER:-not-custom-set}"
 
-# Threshold value multiplier for anti-cheat protection: type 4.
-ANTI_CHEAT_PROTECTION_TYPE_4_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_4_THRESHOLD_MULTIPLIER:-1.0}"
+# Threshold value multiplier for anti-cheat protection: type 4. Minimum=1.00 Maximum=10.00
+ANTI_CHEAT_PROTECTION_TYPE_4_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_4_THRESHOLD_MULTIPLIER:-not-custom-set}"
 
-# Threshold value multiplier for anti-cheat protection: type 9.
-ANTI_CHEAT_PROTECTION_TYPE_9_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_9_THRESHOLD_MULTIPLIER:-1.0}"
+# Threshold value multiplier for anti-cheat protection: type 9. Minimum=1.00 Maximum=10.00
+ANTI_CHEAT_PROTECTION_TYPE_9_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_9_THRESHOLD_MULTIPLIER:-not-custom-set}"
 
-# Threshold value multiplier for anti-cheat protection: type 15.
-ANTI_CHEAT_PROTECTION_TYPE_15_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_15_THRESHOLD_MULTIPLIER:-1.0}"
+# Threshold value multiplier for anti-cheat protection: type 15. Minimum=1.00 Maximum=10.00
+ANTI_CHEAT_PROTECTION_TYPE_15_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_15_THRESHOLD_MULTIPLIER:-not-custom-set}"
 
-# Threshold value multiplier for anti-cheat protection: type 20.
-ANTI_CHEAT_PROTECTION_TYPE_20_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_20_THRESHOLD_MULTIPLIER:-1.0}"
+# Threshold value multiplier for anti-cheat protection: type 20. Minimum=1.00 Maximum=10.00
+ANTI_CHEAT_PROTECTION_TYPE_20_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_20_THRESHOLD_MULTIPLIER:-not-custom-set}"
 
-# Threshold value multiplier for anti-cheat protection: type 22.
-ANTI_CHEAT_PROTECTION_TYPE_22_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_22_THRESHOLD_MULTIPLIER:-1.0}"
+# Threshold value multiplier for anti-cheat protection: type 22. Minimum=1.00 Maximum=10.00
+ANTI_CHEAT_PROTECTION_TYPE_22_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_22_THRESHOLD_MULTIPLIER:-not-custom-set}"
 
-# Threshold value multiplier for anti-cheat protection: type 24.
-ANTI_CHEAT_PROTECTION_TYPE_24_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_24_THRESHOLD_MULTIPLIER:-6.0}"
+# Threshold value multiplier for anti-cheat protection: type 24. Minimum=1.00 Maximum=10.00
+ANTI_CHEAT_PROTECTION_TYPE_24_THRESHOLD_MULTIPLIER="${ANTI_CHEAT_PROTECTION_TYPE_24_THRESHOLD_MULTIPLIER:-not-custom-set}"
 
 # Disable automatic export
 set +a

--- a/zomboid-server/env/server-sandbox-vars.sh
+++ b/zomboid-server/env/server-sandbox-vars.sh
@@ -34,7 +34,7 @@
 # Enable automatic export of all variables
 set -a
 
-VERSION="${VERSION:-5}"
+VERSION="${VERSION:-not-custom-set}"
 
 # Changing this sets the "Population Multiplier" advanced option. Default=Normal
 # 1 = Insane
@@ -42,11 +42,11 @@ VERSION="${VERSION:-5}"
 # 3 = High
 # 4 = Normal
 # 5 = Low
-ZOMBIES="${ZOMBIES:-3}"
+ZOMBIES="${ZOMBIES:-not-custom-set}"
 
 # Default=Urban Focused
 # 1 = Urban Focused
-DISTRIBUTION="${DISTRIBUTION:-1}"
+DISTRIBUTION="${DISTRIBUTION:-not-custom-set}"
 
 # Default=1 Hour
 # 1 = 15 Minutes
@@ -74,9 +74,9 @@ DISTRIBUTION="${DISTRIBUTION:-1}"
 # 23 = 21 Hours
 # 24 = 22 Hours
 # 25 = 23 Hours
-DAY_LENGTH="${DAY_LENGTH:-3}"
+DAY_LENGTH="${DAY_LENGTH:-not-custom-set}"
 
-START_YEAR="${START_YEAR:-1}"
+START_YEAR="${START_YEAR:-not-custom-set}"
 
 # Default=July
 # 1 = January
@@ -90,9 +90,9 @@ START_YEAR="${START_YEAR:-1}"
 # 9 = September
 # 10 = October
 # 11 = November
-START_MONTH="${START_MONTH:-7}"
+START_MONTH="${START_MONTH:-not-custom-set}"
 
-START_DAY="${START_DAY:-9}"
+START_DAY="${START_DAY:-not-custom-set}"
 
 # Default=9 AM
 # 1 = 7 AM
@@ -103,7 +103,7 @@ START_DAY="${START_DAY:-9}"
 # 6 = 9 PM
 # 7 = 12 AM
 # 8 = 2 AM
-START_TIME="${START_TIME:-2}"
+START_TIME="${START_TIME:-not-custom-set}"
 
 # Default=0-30 Days
 # 1 = Instant
@@ -113,7 +113,7 @@ START_TIME="${START_TIME:-2}"
 # 5 = 0-1 Year
 # 6 = 0-5 Years
 # 7 = 2-6 Months
-WATER_SHUT="${WATER_SHUT:-2}"
+WATER_SHUT="${WATER_SHUT:-not-custom-set}"
 
 # Default=0-30 Days
 # 1 = Instant
@@ -123,13 +123,13 @@ WATER_SHUT="${WATER_SHUT:-2}"
 # 5 = 0-1 Year
 # 6 = 0-5 Years
 # 7 = 2-6 Months
-ELEC_SHUT="${ELEC_SHUT:-2}"
+ELEC_SHUT="${ELEC_SHUT:-not-custom-set}"
 
 # Minimum=-1 Maximum=2147483647 Default=14
-WATER_SHUT_MODIFIER="${WATER_SHUT_MODIFIER:-14}"
+WATER_SHUT_MODIFIER="${WATER_SHUT_MODIFIER:-not-custom-set}"
 
 # Minimum=-1 Maximum=2147483647 Default=14
-ELEC_SHUT_MODIFIER="${ELEC_SHUT_MODIFIER:-14}"
+ELEC_SHUT_MODIFIER="${ELEC_SHUT_MODIFIER:-not-custom-set}"
 
 # Default=Rare
 # 1 = None (not recommended)
@@ -138,7 +138,7 @@ ELEC_SHUT_MODIFIER="${ELEC_SHUT_MODIFIER:-14}"
 # 4 = Rare
 # 5 = Normal
 # 6 = Common
-FOOD_LOOT="${FOOD_LOOT:-4}"
+FOOD_LOOT="${FOOD_LOOT:-not-custom-set}"
 
 # Default=Rare
 # 1 = None (not recommended)
@@ -147,7 +147,7 @@ FOOD_LOOT="${FOOD_LOOT:-4}"
 # 4 = Rare
 # 5 = Normal
 # 6 = Common
-CANNED_FOOD_LOOT="${CANNED_FOOD_LOOT:-4}"
+CANNED_FOOD_LOOT="${CANNED_FOOD_LOOT:-not-custom-set}"
 
 # Default=Rare
 # 1 = None (not recommended)
@@ -156,7 +156,7 @@ CANNED_FOOD_LOOT="${CANNED_FOOD_LOOT:-4}"
 # 4 = Rare
 # 5 = Normal
 # 6 = Common
-LITERATURE_LOOT="${LITERATURE_LOOT:-4}"
+LITERATURE_LOOT="${LITERATURE_LOOT:-not-custom-set}"
 
 # Seeds, Nails, Saws, Fishing Rods, various tools, etc... Default=Rare
 # 1 = None (not recommended)
@@ -165,7 +165,7 @@ LITERATURE_LOOT="${LITERATURE_LOOT:-4}"
 # 4 = Rare
 # 5 = Normal
 # 6 = Common
-SURVIVAL_GEARS_LOOT="${SURVIVAL_GEARS_LOOT:-4}"
+SURVIVAL_GEARS_LOOT="${SURVIVAL_GEARS_LOOT:-not-custom-set}"
 
 # Default=Rare
 # 1 = None (not recommended)
@@ -174,7 +174,7 @@ SURVIVAL_GEARS_LOOT="${SURVIVAL_GEARS_LOOT:-4}"
 # 4 = Rare
 # 5 = Normal
 # 6 = Common
-MEDICAL_LOOT="${MEDICAL_LOOT:-4}"
+MEDICAL_LOOT="${MEDICAL_LOOT:-not-custom-set}"
 
 # Default=Rare
 # 1 = None (not recommended)
@@ -183,7 +183,7 @@ MEDICAL_LOOT="${MEDICAL_LOOT:-4}"
 # 4 = Rare
 # 5 = Normal
 # 6 = Common
-WEAPON_LOOT="${WEAPON_LOOT:-4}"
+WEAPON_LOOT="${WEAPON_LOOT:-not-custom-set}"
 
 # Default=Rare
 # 1 = None (not recommended)
@@ -192,7 +192,7 @@ WEAPON_LOOT="${WEAPON_LOOT:-4}"
 # 4 = Rare
 # 5 = Normal
 # 6 = Common
-RANGED_WEAPON_LOOT="${RANGED_WEAPON_LOOT:-4}"
+RANGED_WEAPON_LOOT="${RANGED_WEAPON_LOOT:-not-custom-set}"
 
 # Default=Rare
 # 1 = None (not recommended)
@@ -201,7 +201,7 @@ RANGED_WEAPON_LOOT="${RANGED_WEAPON_LOOT:-4}"
 # 4 = Rare
 # 5 = Normal
 # 6 = Common
-AMMO_LOOT="${AMMO_LOOT:-4}"
+AMMO_LOOT="${AMMO_LOOT:-not-custom-set}"
 
 # Default=Rare
 # 1 = None (not recommended)
@@ -210,7 +210,7 @@ AMMO_LOOT="${AMMO_LOOT:-4}"
 # 4 = Rare
 # 5 = Normal
 # 6 = Common
-MECHANICS_LOOT="${MECHANICS_LOOT:-4}"
+MECHANICS_LOOT="${MECHANICS_LOOT:-not-custom-set}"
 
 # Everything else. Also affects foraging for all items in Town/Road zones. Default=Rare
 # 1 = None (not recommended)
@@ -219,49 +219,49 @@ MECHANICS_LOOT="${MECHANICS_LOOT:-4}"
 # 4 = Rare
 # 5 = Normal
 # 6 = Common
-OTHER_LOOT="${OTHER_LOOT:-4}"
+OTHER_LOOT="${OTHER_LOOT:-not-custom-set}"
 
 # Controls the global temperature. Default=Normal
 # 1 = Very Cold
 # 2 = Cold
 # 3 = Normal
 # 4 = Hot
-TEMPERATURE="${TEMPERATURE:-3}"
+TEMPERATURE="${TEMPERATURE:-not-custom-set}"
 
 # Controls how often it rains. Default=Normal
 # 1 = Very Dry
 # 2 = Dry
 # 3 = Normal
 # 4 = Rainy
-RAIN="${RAIN:-3}"
+RAIN="${RAIN:-not-custom-set}"
 
 # Number of days until 100% growth. Default=Normal (100 Days)
 # 1 = Very Fast (20 Days)
 # 2 = Fast (50 Days)
 # 3 = Normal (100 Days)
 # 4 = Slow (200 Days)
-EROSION_SPEED="${EROSION_SPEED:-3}"
+EROSION_SPEED="${EROSION_SPEED:-not-custom-set}"
 
 # Number of days until 100% growth. -1 means no growth. Zero means use the Erosion Speed option. Maximum 36,500 (100 years). Minimum=-1 Maximum=36500 Default=0
-EROSION_DAYS="${EROSION_DAYS:-0}"
+EROSION_DAYS="${EROSION_DAYS:-not-custom-set}"
 
 # Modifies the base XP gain from actions by this number. Minimum=0.00 Maximum=1000.00 Default=1.00
-XP_MULTIPLIER="${XP_MULTIPLIER:-1.0}"
+XP_MULTIPLIER="${XP_MULTIPLIER:-not-custom-set}"
 
-XP_MULTIPLIER_AFFECTS_PASSIVE="${XP_MULTIPLIER_AFFECTS_PASSIVE:-false}"
+XP_MULTIPLIER_AFFECTS_PASSIVE="${XP_MULTIPLIER_AFFECTS_PASSIVE:-not-custom-set}"
 
 # Use this to multiply or reduce engine general loudness. Minimum=0.00 Maximum=100.00 Default=1.00
-ZOMBIE_ATTRACTION_MULTIPLIER="${ZOMBIE_ATTRACTION_MULTIPLIER:-1.0}"
+ZOMBIE_ATTRACTION_MULTIPLIER="${ZOMBIE_ATTRACTION_MULTIPLIER:-not-custom-set}"
 
 # Governs whether cars are locked, need keys to start etc.
-VEHICLE_EASY_USE="${VEHICLE_EASY_USE:-false}"
+VEHICLE_EASY_USE="${VEHICLE_EASY_USE:-not-custom-set}"
 
 # Controls the speed of plant growth. Default=Normal
 # 1 = Very Fast
 # 2 = Fast
 # 3 = Normal
 # 4 = Slow
-FARMING="${FARMING:-3}"
+FARMING="${FARMING:-not-custom-set}"
 
 # Controls the time it takes for food to break down in a composter. Default=2 Weeks
 # 1 = 1 Week
@@ -271,21 +271,21 @@ FARMING="${FARMING:-3}"
 # 5 = 6 Weeks
 # 6 = 8 Weeks
 # 7 = 10 Weeks
-COMPOST_TIME="${COMPOST_TIME:-2}"
+COMPOST_TIME="${COMPOST_TIME:-not-custom-set}"
 
 # How fast character's hunger, thirst and fatigue will decrease. Default=Normal
 # 1 = Very Fast
 # 2 = Fast
 # 3 = Normal
 # 4 = Slow
-STATS_DECREASE="${STATS_DECREASE:-3}"
+STATS_DECREASE="${STATS_DECREASE:-not-custom-set}"
 
 # Controls the abundance of fish and general forage. Default=Normal
 # 1 = Very Poor
 # 2 = Poor
 # 3 = Normal
 # 4 = Abundant
-NATURE_ABUNDANCE="${NATURE_ABUNDANCE:-3}"
+NATURE_ABUNDANCE="${NATURE_ABUNDANCE:-not-custom-set}"
 
 # Default=Sometimes
 # 1 = Never
@@ -293,7 +293,7 @@ NATURE_ABUNDANCE="${NATURE_ABUNDANCE:-3}"
 # 3 = Rare
 # 4 = Sometimes
 # 5 = Often
-ALARM="${ALARM:-4}"
+ALARM="${ALARM:-not-custom-set}"
 
 # How frequently homes and buildings will be discovered locked Default=Very Often
 # 1 = Never
@@ -301,46 +301,46 @@ ALARM="${ALARM:-4}"
 # 3 = Rare
 # 4 = Sometimes
 # 5 = Often
-LOCKED_HOUSES="${LOCKED_HOUSES:-6}"
+LOCKED_HOUSES="${LOCKED_HOUSES:-not-custom-set}"
 
 # Spawn with chips, water bottle, school bag, baseball bat and a hammer.
-STARTER_KIT="${STARTER_KIT:-false}"
+STARTER_KIT="${STARTER_KIT:-not-custom-set}"
 
 # Nutritional value of food affects the player's condition.
-NUTRITION="${NUTRITION:-true}"
+NUTRITION="${NUTRITION:-not-custom-set}"
 
 # Define how fast the food will spoil inside or outside fridge. Default=Normal
 # 1 = Very Fast
 # 2 = Fast
 # 3 = Normal
 # 4 = Slow
-FOOD_ROT_SPEED="${FOOD_ROT_SPEED:-3}"
+FOOD_ROT_SPEED="${FOOD_ROT_SPEED:-not-custom-set}"
 
 # Define how much a fridge will be effective. Default=Normal
 # 1 = Very Low
 # 2 = Low
 # 3 = Normal
 # 4 = High
-FRIDGE_FACTOR="${FRIDGE_FACTOR:-3}"
+FRIDGE_FACTOR="${FRIDGE_FACTOR:-not-custom-set}"
 
 # Items will respawn in already-looted containers in towns and trailer parks. Items will not respawn in player-made containers. Default=None
 # 1 = None
 # 2 = Every Day
 # 3 = Every Week
 # 4 = Every Month
-LOOT_RESPAWN="${LOOT_RESPAWN:-1}"
+LOOT_RESPAWN="${LOOT_RESPAWN:-not-custom-set}"
 
 # When > 0, loot will not respawn in zones that have been visited within this number of in-game hours. Minimum=0 Maximum=2147483647 Default=0
-SEEN_HOURS_PREVENT_LOOT_RESPAWN="${SEEN_HOURS_PREVENT_LOOT_RESPAWN:-0}"
+SEEN_HOURS_PREVENT_LOOT_RESPAWN="${SEEN_HOURS_PREVENT_LOOT_RESPAWN:-not-custom-set}"
 
 # A comma-separated list of item types that will be removed after HoursForWorldItemRemoval hours.
-WORLD_ITEM_REMOVAL_LIST="${WORLD_ITEM_REMOVAL_LIST:-\"Base.Hat,Base.Glasses,Base.Maggots\"}"
+WORLD_ITEM_REMOVAL_LIST="${WORLD_ITEM_REMOVAL_LIST:-not-custom-set}"
 
 # Number of hours since an item was dropped on the ground before it is removed.  Items are removed the next time that part of the map is loaded.  Zero means items are not removed. Minimum=0.00 Maximum=2147483647.00 Default=24.00
-HOURS_FOR_WORLD_ITEM_REMOVAL="${HOURS_FOR_WORLD_ITEM_REMOVAL:-24.0}"
+HOURS_FOR_WORLD_ITEM_REMOVAL="${HOURS_FOR_WORLD_ITEM_REMOVAL:-not-custom-set}"
 
 # If true, any items *not* in WorldItemRemovalList will be removed.
-ITEM_REMOVAL_LIST_BLACKLIST_TOGGLE="${ITEM_REMOVAL_LIST_BLACKLIST_TOGGLE:-false}"
+ITEM_REMOVAL_LIST_BLACKLIST_TOGGLE="${ITEM_REMOVAL_LIST_BLACKLIST_TOGGLE:-not-custom-set}"
 
 # This will affect starting world erosion and food spoilage. Default=0
 # 1 = 0
@@ -355,54 +355,54 @@ ITEM_REMOVAL_LIST_BLACKLIST_TOGGLE="${ITEM_REMOVAL_LIST_BLACKLIST_TOGGLE:-false}
 # 10 = 9
 # 11 = 10
 # 12 = 11
-TIME_SINCE_APO="${TIME_SINCE_APO:-1}"
+TIME_SINCE_APO="${TIME_SINCE_APO:-not-custom-set}"
 
 # Will influence how much water the plant will lose per day and their ability to avoid disease. Default=Normal
 # 1 = Very High
 # 2 = High
 # 3 = Normal
 # 4 = Low
-PLANT_RESILIENCE="${PLANT_RESILIENCE:-3}"
+PLANT_RESILIENCE="${PLANT_RESILIENCE:-not-custom-set}"
 
 # Controls the yield of plants when harvested. Default=Normal
 # 1 = Very Poor
 # 2 = Poor
 # 3 = Normal
 # 4 = Abundant
-PLANT_ABUNDANCE="${PLANT_ABUNDANCE:-3}"
+PLANT_ABUNDANCE="${PLANT_ABUNDANCE:-not-custom-set}"
 
 # Recovery from being tired from performing actions Default=Normal
 # 1 = Very Fast
 # 2 = Fast
 # 3 = Normal
 # 4 = Slow
-END_REGEN="${END_REGEN:-3}"
+END_REGEN="${END_REGEN:-not-custom-set}"
 
 # How regularly helicopters pass over the event zone. Default=Once
 # 1 = Never
 # 2 = Once
 # 3 = Sometimes
-HELICOPTER="${HELICOPTER:-2}"
+HELICOPTER="${HELICOPTER:-not-custom-set}"
 
 # How often zombie attracting metagame events like distant gunshots will occur. Default=Sometimes
 # 1 = Never
 # 2 = Sometimes
-META_EVENT="${META_EVENT:-2}"
+META_EVENT="${META_EVENT:-not-custom-set}"
 
 # Governs night-time metagame events during the player's sleep. Default=Never
 # 1 = Never
 # 2 = Sometimes
-SLEEPING_EVENT="${SLEEPING_EVENT:-1}"
+SLEEPING_EVENT="${SLEEPING_EVENT:-not-custom-set}"
 
 # Increase/decrease the chance of electrical generators spawning on the map. Default=Sometimes
 # 1 = Extremely Rare
 # 2 = Rare
 # 3 = Sometimes
 # 4 = Often
-GENERATOR_SPAWNING="${GENERATOR_SPAWNING:-3}"
+GENERATOR_SPAWNING="${GENERATOR_SPAWNING:-not-custom-set}"
 
 # How much fuel is consumed per in-game hour. Minimum=0.00 Maximum=100.00 Default=1.00
-GENERATOR_FUEL_CONSUMPTION="${GENERATOR_FUEL_CONSUMPTION:-1.0}"
+GENERATOR_FUEL_CONSUMPTION="${GENERATOR_FUEL_CONSUMPTION:-not-custom-set}"
 
 # Increase/decrease probability of discovering randomized safe houses on the map: either burnt out, containing loot stashes, dead survivor bodies etc. Default=Rare
 # 1 = Never
@@ -410,7 +410,7 @@ GENERATOR_FUEL_CONSUMPTION="${GENERATOR_FUEL_CONSUMPTION:-1.0}"
 # 3 = Rare
 # 4 = Sometimes
 # 5 = Often
-SURVIVOR_HOUSE_CHANCE="${SURVIVOR_HOUSE_CHANCE:-3}"
+SURVIVOR_HOUSE_CHANCE="${SURVIVOR_HOUSE_CHANCE:-not-custom-set}"
 
 # Default=Rare
 # 1 = Never
@@ -418,7 +418,7 @@ SURVIVOR_HOUSE_CHANCE="${SURVIVOR_HOUSE_CHANCE:-3}"
 # 3 = Rare
 # 4 = Sometimes
 # 5 = Often
-VEHICLE_STORY_CHANCE="${VEHICLE_STORY_CHANCE:-3}"
+VEHICLE_STORY_CHANCE="${VEHICLE_STORY_CHANCE:-not-custom-set}"
 
 # Default=Rare
 # 1 = Never
@@ -426,7 +426,7 @@ VEHICLE_STORY_CHANCE="${VEHICLE_STORY_CHANCE:-3}"
 # 3 = Rare
 # 4 = Sometimes
 # 5 = Often
-ZONE_STORY_CHANCE="${ZONE_STORY_CHANCE:-3}"
+ZONE_STORY_CHANCE="${ZONE_STORY_CHANCE:-not-custom-set}"
 
 # Impacts on how often a looted map will have annotations marked on it by a deceased survivor. Default=Sometimes
 # 1 = Never
@@ -434,104 +434,104 @@ ZONE_STORY_CHANCE="${ZONE_STORY_CHANCE:-3}"
 # 3 = Rare
 # 4 = Sometimes
 # 5 = Often
-ANNOTATED_MAP_CHANCE="${ANNOTATED_MAP_CHANCE:-4}"
+ANNOTATED_MAP_CHANCE="${ANNOTATED_MAP_CHANCE:-not-custom-set}"
 
 # Adds free points during character creation. Minimum=-100 Maximum=100 Default=0
-CHARACTER_FREE_POINTS="${CHARACTER_FREE_POINTS:-0}"
+CHARACTER_FREE_POINTS="${CHARACTER_FREE_POINTS:-not-custom-set}"
 
 # Gives player-built constructions extra hit points so they are more resistant to zombie damage. Default=Normal
 # 1 = Very Low
 # 2 = Low
 # 3 = Normal
 # 4 = High
-CONSTRUCTION_BONUS_POINTS="${CONSTRUCTION_BONUS_POINTS:-3}"
+CONSTRUCTION_BONUS_POINTS="${CONSTRUCTION_BONUS_POINTS:-not-custom-set}"
 
 # Governs the ambient lighting at night. Default=Normal
 # 1 = Pitch Black
 # 2 = Dark
 # 3 = Normal
-NIGHT_DARKNESS="${NIGHT_DARKNESS:-3}"
+NIGHT_DARKNESS="${NIGHT_DARKNESS:-not-custom-set}"
 
-NIGHT_LENGTH="${NIGHT_LENGTH:-3}"
+NIGHT_LENGTH="${NIGHT_LENGTH:-not-custom-set}"
 
 # Increase and decrease the impact injuries have on your body, and their healing time. Default=Normal
 # 1 = Low
 # 2 = Normal
-INJURY_SEVERITY="${INJURY_SEVERITY:-2}"
+INJURY_SEVERITY="${INJURY_SEVERITY:-not-custom-set}"
 
 # Enable or disable broken limbs when survivors receive injuries from impacts, zombie damage and falls.
-BONE_FRACTURE="${BONE_FRACTURE:-true}"
+BONE_FRACTURE="${BONE_FRACTURE:-not-custom-set}"
 
 # How long before zombie bodies disappear. Minimum=-1.00 Maximum=2147483647.00 Default=216.00
-HOURS_FOR_CORPSE_REMOVAL="${HOURS_FOR_CORPSE_REMOVAL:-216.0}"
+HOURS_FOR_CORPSE_REMOVAL="${HOURS_FOR_CORPSE_REMOVAL:-not-custom-set}"
 
 # Governs impact that nearby decaying bodies has on the player's health and emotions. Default=Normal
 # 1 = None
 # 2 = Low
 # 3 = Normal
-DECAYING_CORPSE_HEALTH_IMPACT="${DECAYING_CORPSE_HEALTH_IMPACT:-3}"
+DECAYING_CORPSE_HEALTH_IMPACT="${DECAYING_CORPSE_HEALTH_IMPACT:-not-custom-set}"
 
 # How much blood is sprayed on floor and walls. Default=Normal
 # 1 = None
 # 2 = Low
 # 3 = Normal
 # 4 = High
-BLOOD_LEVEL="${BLOOD_LEVEL:-3}"
+BLOOD_LEVEL="${BLOOD_LEVEL:-not-custom-set}"
 
 # Governs how quickly clothing degrades, becomes dirty, and bloodied. Default=Normal
 # 1 = Disabled
 # 2 = Slow
 # 3 = Normal
-CLOTHING_DEGRADATION="${CLOTHING_DEGRADATION:-3}"
+CLOTHING_DEGRADATION="${CLOTHING_DEGRADATION:-not-custom-set}"
 
-FIRE_SPREAD="${FIRE_SPREAD:-true}"
+FIRE_SPREAD="${FIRE_SPREAD:-not-custom-set}"
 
 # Number of in-game days before rotten food is removed from the map. -1 means rotten food is never removed. Minimum=-1 Maximum=2147483647 Default=-1
-DAYS_FOR_ROTTEN_FOOD_REMOVAL="${DAYS_FOR_ROTTEN_FOOD_REMOVAL:--1}"
+DAYS_FOR_ROTTEN_FOOD_REMOVAL="${DAYS_FOR_ROTTEN_FOOD_REMOVAL:-not-custom-set}"
 
 # If enabled, generators will work on exterior tiles, allowing for example to power gas pump.
-ALLOW_EXTERIOR_GENERATOR="${ALLOW_EXTERIOR_GENERATOR:-true}"
+ALLOW_EXTERIOR_GENERATOR="${ALLOW_EXTERIOR_GENERATOR:-not-custom-set}"
 
 # Controls the maximum intensity of fog. Default=Normal
 # 1 = Normal
 # 2 = Moderate
-MAX_FOG_INTENSITY="${MAX_FOG_INTENSITY:-1}"
+MAX_FOG_INTENSITY="${MAX_FOG_INTENSITY:-not-custom-set}"
 
 # Controls the maximum intensity of rain. Default=Normal
 # 1 = Normal
 # 2 = Moderate
-MAX_RAIN_FX_INTENSITY="${MAX_RAIN_FX_INTENSITY:-1}"
+MAX_RAIN_FX_INTENSITY="${MAX_RAIN_FX_INTENSITY:-not-custom-set}"
 
 # If disabled snow will not accumulate on ground but will still be visible on vegetation and rooftops.
-ENABLE_SNOW_ON_GROUND="${ENABLE_SNOW_ON_GROUND:-true}"
+ENABLE_SNOW_ON_GROUND="${ENABLE_SNOW_ON_GROUND:-not-custom-set}"
 
 # if disabled, tainted water will not have a warning marking it as such
-ENABLE_TAINTED_WATER_TEXT="${ENABLE_TAINTED_WATER_TEXT:-true}"
+ENABLE_TAINTED_WATER_TEXT="${ENABLE_TAINTED_WATER_TEXT:-not-custom-set}"
 
 # When enabled certain melee weapons will be able to strike multiple zombies in one hit.
-MULTI_HIT_ZOMBIES="${MULTI_HIT_ZOMBIES:-false}"
+MULTI_HIT_ZOMBIES="${MULTI_HIT_ZOMBIES:-not-custom-set}"
 
 # Chance of being bitten when a zombie attacks from behind. Default=High
 # 1 = Low
 # 2 = Medium
-REAR_VULNERABILITY="${REAR_VULNERABILITY:-3}"
+REAR_VULNERABILITY="${REAR_VULNERABILITY:-not-custom-set}"
 
 # Disable to walk unimpeded while melee attacking.
-ATTACK_BLOCK_MOVEMENTS="${ATTACK_BLOCK_MOVEMENTS:-true}"
+ATTACK_BLOCK_MOVEMENTS="${ATTACK_BLOCK_MOVEMENTS:-not-custom-set}"
 
-ALL_CLOTHES_UNLOCKED="${ALL_CLOTHES_UNLOCKED:-false}"
+ALL_CLOTHES_UNLOCKED="${ALL_CLOTHES_UNLOCKED:-not-custom-set}"
 
 # Governs how frequently cars are discovered on the map Default=Low
 # 1 = None
 # 2 = Very Low
 # 3 = Low
 # 4 = Normal
-CAR_SPAWN_RATE="${CAR_SPAWN_RATE:-3}"
+CAR_SPAWN_RATE="${CAR_SPAWN_RATE:-not-custom-set}"
 
 # Governs the chances of finding vehicles with gas in the tank. Default=Low
 # 1 = Low
 # 2 = Normal
-CHANCE_HAS_GAS="${CHANCE_HAS_GAS:-1}"
+CHANCE_HAS_GAS="${CHANCE_HAS_GAS:-not-custom-set}"
 
 # Governs how full gas tanks will be in discovered cars. Default=Low
 # 1 = Very Low
@@ -539,7 +539,7 @@ CHANCE_HAS_GAS="${CHANCE_HAS_GAS:-1}"
 # 3 = Normal
 # 4 = High
 # 5 = Very High
-INITIAL_GAS="${INITIAL_GAS:-2}"
+INITIAL_GAS="${INITIAL_GAS:-not-custom-set}"
 
 # Governs how full gas tanks in fuel station will be, initially. Default=Normal
 # 1 = Empty
@@ -550,10 +550,10 @@ INITIAL_GAS="${INITIAL_GAS:-2}"
 # 6 = High
 # 7 = Very High
 # 8 = Full
-FUEL_STATION_GAS="${FUEL_STATION_GAS:-5}"
+FUEL_STATION_GAS="${FUEL_STATION_GAS:-not-custom-set}"
 
 # How gas-hungry vehicles on the map are. Minimum=0.00 Maximum=100.00 Default=1.00
-CAR_GAS_CONSUMPTION="${CAR_GAS_CONSUMPTION:-1.0}"
+CAR_GAS_CONSUMPTION="${CAR_GAS_CONSUMPTION:-not-custom-set}"
 
 # Default=Rare
 # 1 = Never
@@ -561,31 +561,31 @@ CAR_GAS_CONSUMPTION="${CAR_GAS_CONSUMPTION:-1.0}"
 # 3 = Rare
 # 4 = Sometimes
 # 5 = Often
-LOCKED_CAR="${LOCKED_CAR:-3}"
+LOCKED_CAR="${LOCKED_CAR:-not-custom-set}"
 
 # General condition of vehicles discovered on the map Default=Low
 # 1 = Very Low
 # 2 = Low
 # 3 = Normal
 # 4 = High
-CAR_GENERAL_CONDITION="${CAR_GENERAL_CONDITION:-2}"
+CAR_GENERAL_CONDITION="${CAR_GENERAL_CONDITION:-not-custom-set}"
 
 # Governs the amount of damage dealt to vehicles that crash. Default=Normal
 # 1 = Very Low
 # 2 = Low
 # 3 = Normal
 # 4 = High
-CAR_DAMAGE_ON_IMPACT="${CAR_DAMAGE_ON_IMPACT:-3}"
+CAR_DAMAGE_ON_IMPACT="${CAR_DAMAGE_ON_IMPACT:-not-custom-set}"
 
 # Damage received by the player from the car in a collision. Default=None
 # 1 = None
 # 2 = Low
 # 3 = Normal
 # 4 = High
-DAMAGE_TO_PLAYER_FROM_HIT_BY_A_CAR="${DAMAGE_TO_PLAYER_FROM_HIT_BY_A_CAR:-1}"
+DAMAGE_TO_PLAYER_FROM_HIT_BY_A_CAR="${DAMAGE_TO_PLAYER_FROM_HIT_BY_A_CAR:-not-custom-set}"
 
 # Enable or disable traffic jams that spawn on the main roads of the map.
-TRAFFIC_JAM="${TRAFFIC_JAM:-true}"
+TRAFFIC_JAM="${TRAFFIC_JAM:-not-custom-set}"
 
 # How frequently cars will be discovered with an alarm. Default=Extremely Rare
 # 1 = Never
@@ -593,42 +593,42 @@ TRAFFIC_JAM="${TRAFFIC_JAM:-true}"
 # 3 = Rare
 # 4 = Sometimes
 # 5 = Often
-CAR_ALARM="${CAR_ALARM:-2}"
+CAR_ALARM="${CAR_ALARM:-not-custom-set}"
 
 # Enable or disable player getting damage from being in a car accident.
-PLAYER_DAMAGE_FROM_CRASH="${PLAYER_DAMAGE_FROM_CRASH:-true}"
+PLAYER_DAMAGE_FROM_CRASH="${PLAYER_DAMAGE_FROM_CRASH:-not-custom-set}"
 
 # How many in-game hours before a wailing siren shuts off. Minimum=0.00 Maximum=168.00 Default=0.00
-SIREN_SHUTOFF_HOURS="${SIREN_SHUTOFF_HOURS:-0.0}"
+SIREN_SHUTOFF_HOURS="${SIREN_SHUTOFF_HOURS:-not-custom-set}"
 
 #  Governs whether player can discover a car that has been maintained and cared for after the infection struck. Default=Low
 # 1 = None
 # 2 = Low
 # 3 = Normal
-RECENTLY_SURVIVOR_VEHICLES="${RECENTLY_SURVIVOR_VEHICLES:-2}"
+RECENTLY_SURVIVOR_VEHICLES="${RECENTLY_SURVIVOR_VEHICLES:-not-custom-set}"
 
 # Enables vehicles to spawn.
-ENABLE_VEHICLES="${ENABLE_VEHICLES:-true}"
+ENABLE_VEHICLES="${ENABLE_VEHICLES:-not-custom-set}"
 
 # Governs if poisoning food is enabled. Default=True
 # 1 = True
 # 2 = False
-ENABLE_POISONING="${ENABLE_POISONING:-1}"
+ENABLE_POISONING="${ENABLE_POISONING:-not-custom-set}"
 
 # Default=In and around bodies
 # 1 = In and around bodies
 # 2 = In bodies only
-MAGGOT_SPAWN="${MAGGOT_SPAWN:-1}"
+MAGGOT_SPAWN="${MAGGOT_SPAWN:-not-custom-set}"
 
 # The higher the value, the longer lightbulbs last before breaking. If 0, lightbulbs will never break.
 # Does not affect vehicle headlights. Minimum=0.00 Maximum=1000.00 Default=1.00
-LIGHT_BULB_LIFESPAN="${LIGHT_BULB_LIFESPAN:-1.0}"
+LIGHT_BULB_LIFESPAN="${LIGHT_BULB_LIFESPAN:-not-custom-set}"
 
 # --------------------------------------------------------------
 # Nested categories for map settings
-ALLOW_MINI_MAP="${ALLOW_MINI_MAP:-false}"
-ALLOW_WORLD_MAP="${ALLOW_WORLD_MAP:-true}"
-MAP_ALL_KNOWN="${MAP_ALL_KNOWN:-false}"
+ALLOW_MINI_MAP="${ALLOW_MINI_MAP:-not-custom-set}"
+ALLOW_WORLD_MAP="${ALLOW_WORLD_MAP:-not-custom-set}"
+MAP_ALL_KNOWN="${MAP_ALL_KNOWN:-not-custom-set}"
 
 # --------------------------------------------------------------
 # Nested categories for zombie lore settings
@@ -636,25 +636,25 @@ MAP_ALL_KNOWN="${MAP_ALL_KNOWN:-false}"
 # 1 = Sprinters
 # 2 = Fast Shamblers
 # 3 = Shamblers
-SPEED="${SPEED:-2}"
+SPEED="${SPEED:-not-custom-set}"
 
 # Controls the damage zombies inflict per attack. Default=Normal
 # 1 = Superhuman
 # 2 = Normal
 # 3 = Weak
-STRENGTH="${STRENGTH:-2}"
+STRENGTH="${STRENGTH:-not-custom-set}"
 
 # Controls the difficulty to kill zombies. Default=Normal
 # 1 = Tough
 # 2 = Normal
 # 3 = Fragile
-TOUGHNESS="${TOUGHNESS:-2}"
+TOUGHNESS="${TOUGHNESS:-not-custom-set}"
 
 # Controls how the zombie virus spreads. Default=Blood + Saliva
 # 1 = Blood + Saliva
 # 2 = Saliva Only
 # 3 = Everyone's Infected
-TRANSMISSION="${TRANSMISSION:-1}"
+TRANSMISSION="${TRANSMISSION:-not-custom-set}"
 
 # Controls how quickly the infection takes effect. Default=2-3 Days
 # 1 = Instant
@@ -663,7 +663,7 @@ TRANSMISSION="${TRANSMISSION:-1}"
 # 4 = 0-12 Hours
 # 5 = 2-3 Days
 # 6 = 1-2 Weeks
-MORTALITY="${MORTALITY:-5}"
+MORTALITY="${MORTALITY:-not-custom-set}"
 
 # Controls how quickly corpses rise as zombies. Default=0-1 Minutes
 # 1 = Instant
@@ -671,13 +671,13 @@ MORTALITY="${MORTALITY:-5}"
 # 3 = 0-1 Minutes
 # 4 = 0-12 Hours
 # 5 = 2-3 Days
-REANIMATE="${REANIMATE:-3}"
+REANIMATE="${REANIMATE:-not-custom-set}"
 
 # Controls zombie intelligence. Default=Basic Navigation
 # 1 = Navigate + Use Doors
 # 2 = Navigate
 # 3 = Basic Navigation
-COGNITION="${COGNITION:-3}"
+COGNITION="${COGNITION:-not-custom-set}"
 
 # Controls which zombies can crawl under vehicles. Default=Often
 # 1 = Crawlers Only
@@ -686,92 +686,92 @@ COGNITION="${COGNITION:-3}"
 # 4 = Sometimes
 # 5 = Often
 # 6 = Very Often
-CRAWL_UNDER_VEHICLE="${CRAWL_UNDER_VEHICLE:-5}"
+CRAWL_UNDER_VEHICLE="${CRAWL_UNDER_VEHICLE:-not-custom-set}"
 
 # Controls how long zombies remember players after seeing or hearing. Default=Normal
 # 1 = Long
 # 2 = Normal
 # 3 = Short
 # 4 = None
-MEMORY="${MEMORY:-2}"
+MEMORY="${MEMORY:-not-custom-set}"
 
 # Controls zombie vision radius. Default=Normal
 # 1 = Eagle
 # 2 = Normal
 # 3 = Poor
-SIGHT="${SIGHT:-2}"
+SIGHT="${SIGHT:-not-custom-set}"
 
 # Controls zombie hearing radius. Default=Normal
 # 1 = Pinpoint
 # 2 = Normal
 # 3 = Poor
-HEARING="${HEARING:-2}"
+HEARING="${HEARING:-not-custom-set}"
 
 # Zombies that have not seen/heard player can attack doors and constructions while roaming.
-THUMP_NO_CHASING="${THUMP_NO_CHASING:-false}"
+THUMP_NO_CHASING="${THUMP_NO_CHASING:-not-custom-set}"
 
 # Governs whether or not zombies can destroy player constructions and defences.
-THUMP_ON_CONSTRUCTION="${THUMP_ON_CONSTRUCTION:-true}"
+THUMP_ON_CONSTRUCTION="${THUMP_ON_CONSTRUCTION:-not-custom-set}"
 
 # Governs whether zombies are more active during the day, or whether they act more nocturnally.  Active zombies will use the speed set in the "Speed" setting. Inactive zombies will be slower, and tend not to give chase. Default=Both
 # 1 = Both
 # 2 = Night
-ACTIVE_ONLY="${ACTIVE_ONLY:-1}"
+ACTIVE_ONLY="${ACTIVE_ONLY:-not-custom-set}"
 
 # Allows zombies to trigger house alarms when breaking through windows and doors.
-TRIGGER_HOUSE_ALARM="${TRIGGER_HOUSE_ALARM:-false}"
+TRIGGER_HOUSE_ALARM="${TRIGGER_HOUSE_ALARM:-not-custom-set}"
 
 # When enabled if multiple zombies are attacking they can drag you down to feed. Dependent on zombie strength.
-ZOMBIES_DRAG_DOWN="${ZOMBIES_DRAG_DOWN:-true}"
+ZOMBIES_DRAG_DOWN="${ZOMBIES_DRAG_DOWN:-not-custom-set}"
 
 # When enabled zombies will have a chance to lunge after climbing over a fence if you're too close.
-ZOMBIES_FENCE_LUNGE="${ZOMBIES_FENCE_LUNGE:-true}"
+ZOMBIES_FENCE_LUNGE="${ZOMBIES_FENCE_LUNGE:-not-custom-set}"
 
 # Default=Some zombies in the world will pretend to be dead
 # 1 = Some zombies in the world will pretend to be dead
 # 2 = Some zombies in the world, as well as some you 'kill', can pretend to be dead
-DISABLE_FAKE_DEAD="${DISABLE_FAKE_DEAD:-1}"
+DISABLE_FAKE_DEAD="${DISABLE_FAKE_DEAD:-not-custom-set}"
 
 # --------------------------------------------------------------
 # Nested categories for zombie settings
 # Set by the "Zombie Count" population option. 4.0 = Insane, Very High = 3.0, 2.0 = High, 1.0 = Normal, 0.35 = Low, 0.0 = None. Minimum=0.00 Maximum=4.00 Default=1.00
-POPULATION_MULTIPLIER="${POPULATION_MULTIPLIER:-1.0}"
+POPULATION_MULTIPLIER="${POPULATION_MULTIPLIER:-not-custom-set}"
 
 # Adjusts the desired population at the start of the game. Minimum=0.00 Maximum=4.00 Default=1.00
-POPULATION_START_MULTIPLIER="${POPULATION_START_MULTIPLIER:-1.0}"
+POPULATION_START_MULTIPLIER="${POPULATION_START_MULTIPLIER:-not-custom-set}"
 
 # Adjusts the desired population on the peak day. Minimum=0.00 Maximum=4.00 Default=1.50
-POPULATION_PEAK_MULTIPLIER="${POPULATION_PEAK_MULTIPLIER:-1.5}"
+POPULATION_PEAK_MULTIPLIER="${POPULATION_PEAK_MULTIPLIER:-not-custom-set}"
 
 # The day when the population reaches it's peak. Minimum=1 Maximum=365 Default=28
-POPULATION_PEAK_DAY="${POPULATION_PEAK_DAY:-28}"
+POPULATION_PEAK_DAY="${POPULATION_PEAK_DAY:-not-custom-set}"
 
 # The number of hours that must pass before zombies may respawn in a cell. If zero, spawning is disabled. Minimum=0.00 Maximum=8760.00 Default=72.00
-RESPAWN_HOURS="${RESPAWN_HOURS:-72.0}"
+RESPAWN_HOURS="${RESPAWN_HOURS:-not-custom-set}"
 
 # The number of hours that a chunk must be unseen before zombies may respawn in it. Minimum=0.00 Maximum=8760.00 Default=16.00
-RESPAWN_UNSEEN_HOURS="${RESPAWN_UNSEEN_HOURS:-16.0}"
+RESPAWN_UNSEEN_HOURS="${RESPAWN_UNSEEN_HOURS:-not-custom-set}"
 
 # The fraction of a cell's desired population that may respawn every RespawnHours. Minimum=0.00 Maximum=1.00 Default=0.10
-RESPAWN_MULTIPLIER="${RESPAWN_MULTIPLIER:-0.1}"
+RESPAWN_MULTIPLIER="${RESPAWN_MULTIPLIER:-not-custom-set}"
 
 # The number of hours that must pass before zombies migrate to empty parts of the same cell. If zero, migration is disabled. Minimum=0.00 Maximum=8760.00 Default=12.00
-REDISTRIBUTE_HOURS="${REDISTRIBUTE_HOURS:-12.0}"
+REDISTRIBUTE_HOURS="${REDISTRIBUTE_HOURS:-not-custom-set}"
 
 # The distance a zombie will try to walk towards the last sound it heard. Minimum=10 Maximum=1000 Default=100
-FOLLOW_SOUND_DISTANCE="${FOLLOW_SOUND_DISTANCE:-100}"
+FOLLOW_SOUND_DISTANCE="${FOLLOW_SOUND_DISTANCE:-not-custom-set}"
 
 # The size of groups real zombies form when idle. Zero means zombies don't form groups. Groups don't form inside buildings or forest zones. Minimum=0 Maximum=1000 Default=20
-RALLY_GROUP_SIZE="${RALLY_GROUP_SIZE:-20}"
+RALLY_GROUP_SIZE="${RALLY_GROUP_SIZE:-not-custom-set}"
 
 # The distance real zombies travel to form groups when idle. Minimum=5 Maximum=50 Default=20
-RALLY_TRAVEL_DISTANCE="${RALLY_TRAVEL_DISTANCE:-20}"
+RALLY_TRAVEL_DISTANCE="${RALLY_TRAVEL_DISTANCE:-not-custom-set}"
 
 # The distance between zombie groups. Minimum=5 Maximum=25 Default=15
-RALLY_GROUP_SEPARATION="${RALLY_GROUP_SEPARATION:-15}"
+RALLY_GROUP_SEPARATION="${RALLY_GROUP_SEPARATION:-not-custom-set}"
 
 # How close members of a group stay to the group's leader. Minimum=1 Maximum=10 Default=3
-RALLY_GROUP_RADIUS="${RALLY_GROUP_RADIUS:-3}"
+RALLY_GROUP_RADIUS="${RALLY_GROUP_RADIUS:-not-custom-set}"
 
 # Disable automatic export
 set +a

--- a/zomboid-server/scripts/build/generate-defaults.sh
+++ b/zomboid-server/scripts/build/generate-defaults.sh
@@ -9,12 +9,16 @@
 # It waits for up to 120 seconds for the file to be created, then stops the server.
 # If the file is not created within the timeout, it exits with an error.
 #
+# The generated files are copied to /defaults/default_SandboxVars.lua and
+# /defaults/default.ini.
+#
 # Usage:
 #   ./generate-defaults.sh
 #
 
 SERVER_DIR="${SERVER_DIR:-/pzomboid-server}"
 CACHE_DIR="${CACHE_DIR:-/root/Zomboid}"
+DEFAULTS_DIR="${DEFAULTS_DIR:-/defaults}"
 SECONDS=0
 
 set -euo pipefail
@@ -47,6 +51,11 @@ if [[ ! -f "${CACHE_DIR}/Server/servertest_SandboxVars.lua" ]]; then
 	kill "${server_pid}" || true
 	exit 1
 fi
+
+echo "Moving generated config files to ${DEFAULTS_DIR}..."
+mkdir -p "${DEFAULTS_DIR}"
+mv -f "${CACHE_DIR}/Server/servertest_SandboxVars.lua" "${DEFAULTS_DIR}/default_SandboxVars.lua"
+mv -f "${CACHE_DIR}/Server/servertest.ini" "${DEFAULTS_DIR}/default.ini"
 
 echo "File generated. Stopping server (PID: ${server_pid})..."
 kill "${server_pid}" || true

--- a/zomboid-server/scripts/entrypoint.sh
+++ b/zomboid-server/scripts/entrypoint.sh
@@ -27,8 +27,6 @@ if [[ -z "${HAS_CONTENTS}" ]]; then
 	cp -r /zomboid-data/. "${CACHE_DIR}/"
 fi
 
-echo "updating server configuration with environment variables..."
-
 # Update server configuration for custom settings
 if [[ -f "${SERVER_CONFIG_UPDATE_SCRIPT}" ]]; then
 	(cd "${DIR}/setup" && python3 update_server_config.py)
@@ -41,6 +39,9 @@ if [[ ! -x "${SERVER_INIT_SCRIPT}" ]]; then
 	echo "Error: Server initialization script not found or not executable: ${SERVER_INIT_SCRIPT}"
 	exit 1
 fi
+
+echo "Server configuration has been updated. Continuing in 5 seconds..."
+sleep 5
 
 # Execute the server initialization script
 # If no arguments are provided, run the server as default

--- a/zomboid-server/scripts/init-server.sh
+++ b/zomboid-server/scripts/init-server.sh
@@ -35,7 +35,7 @@ if [[ -n "${SERVER_NAME}" ]]; then
 fi
 [[ -n "${IP}" ]] && ARGS+=("${IP} -ip" "${IP}")
 [[ -n "${PORT}" ]] && ARGS+=("-port" "${PORT}")
-[[ -n "${STEAM_VAC}" ]] && ARGS+=("-steam_vac" "${STEAM_VAC,,}")
+[[ -n "${STEAM_VAC}" ]] && ARGS+=("-steamvac" "${STEAM_VAC,,}")
 [[ -n "${STEAM_PORT_1}" ]] && ARGS+=("-steamport1" "${STEAM_PORT_1}")
 [[ -n "${STEAM_PORT_2}" ]] && ARGS+=("-steamport2" "${STEAM_PORT_2}")
 

--- a/zomboid-server/scripts/setup/helpers.py
+++ b/zomboid-server/scripts/setup/helpers.py
@@ -4,18 +4,26 @@ import re
 import sys
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-
-if not logger.hasHandlers():
-    handler = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter("%(levelname)s: %(message)s")
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-
 REGEX = re.compile(
     r"^(.*?)(\b\w+\b)(\s*=\s*)(\"(?:[^\"\\\\]|\\\\.)*\"|'(?:[^'\\\\]|\\\\.)*'|.*?)(?=\s*,?\s*(?:#.*)?$)(\s*,?\s*(?:#.*)?)$",
 )
+
+
+def setup_logger() -> logging.Logger:
+    """Set up and return a logger with INFO level and stream handler.
+
+    Returns:
+        logging.Logger: Configured logger instance.
+
+    """
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
+    if not logger.hasHandlers():
+        handler = logging.StreamHandler(sys.stdout)
+        formatter = logging.Formatter("%(levelname)s: %(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    return logger
 
 
 def is_line_valid(line: str) -> bool:
@@ -42,51 +50,15 @@ def is_line_valid(line: str) -> bool:
     )
 
 
-def load_variables(file_path: str | None = None) -> dict:
-    """Load environment variables from the system or a specified file.
-
-    If no file path is provided, returns a dictionary of the current system
-    environment variables. If a file path is given, reads the file and parses
-    lines in the format 'KEY = VALUE', supporting quoted and unquoted values.
-    Ignores comments and blank lines. Logs a warning for lines that do not
-    match the expected format.
-
-    Args:
-        file_path (str | None): Path to an environment file to load variables from.
-            If None, loads from the current system environment.
+def load_custom_variables() -> dict:
+    """Load the custom environment variables.
 
     Returns:
-        dict: A dictionary containing environment variables as key-value pairs.
-
-    Raises:
-        FileNotFoundError: If the specified file does not exist.
+        dict: A dictionary containing the custom environment variables as
+            key-value pairs, excluding those with 'no-custom-set' value.
 
     """
-    if not file_path:
-        return dict(os.environ)
-
-    if not Path(file_path).exists():
-        logger.error("Environment file '%s' does not exist.", file_path)
-        msg = f"File '{file_path}' not found."
-        raise FileNotFoundError(msg)
-
-    with Path(file_path).open() as file:
-        lines = file.readlines()
-        env_vars = {}
-
-        for line in lines:
-            stripped_line = line.strip()
-            if not is_line_valid(stripped_line):
-                continue
-
-            match = re.match(REGEX, stripped_line)
-            if match:
-                key, value = match.group(2), match.group(4)
-                env_vars[key] = value
-            else:
-                logger.warning("Line '%s' does not match the format.", stripped_line)
-
-    return env_vars
+    return {k: v for k, v in dict(os.environ).items() if v != "not-custom-set"}
 
 
 def convert_to_flatcase(text: str) -> str:
@@ -109,53 +81,27 @@ def convert_to_flatcase(text: str) -> str:
     return re.sub(r"[-_\s]", "", text)
 
 
-def extract_differential_values(config_map: dict, default_map: dict) -> dict:
-    """Extract pairs from config_map whose values differ from those in default_map.
-
-    Only include keys that exist in default_map. Key comparison is done in
-    flatcase.
-
-    Args:
-        config_map (dict): The configuration map to filter.
-        default_map (dict): The reference map of default values.
-
-    Returns:
-        dict: A new dict containing only those entries from config_map whose
-        flattened keys are present in default_map and whose values differ.
-
-    """
-    flat_default = {convert_to_flatcase(k): v for k, v in default_map.items()}
-
-    return {
-        convert_to_flatcase(key): value
-        for key, value in config_map.items()
-        if (
-            (fk := convert_to_flatcase(key)) in flat_default
-            and flat_default[fk] != value
-        )
-    }
-
-
-def replace_file_variables(
+def rewrite_file_variables(
     file_path: str,
     variables_dict: dict,
-    server_name: str,
+    new_file_path: str,
 ) -> None:
-    """Replace variables in a configuration file with new values.
+    """Replace variables in a config file with new values and write to a new file.
 
-    Reads the specified file, updates lines containing variables found in
-    variables_dict, and writes the updated content to a new file whose name
-    replaces 'servertest' with the given server_name.
+    Reads the file at file_path, finds lines containing variables present in vars_dict,
+    and replaces their values with those from vars_dict. The updated content is written
+    to new_file_path. Variable name matching is case-insensitive and ignores separators.
 
     Args:
-        file_path (str): Path to the configuration file to update.
-        variables_dict (dict): Dictionary of variable names and their new values.
-        server_name (str): Name to use in the output file name.
+        file_path (str): Path to the input configuration file.
+        variables_dict (dict): Mapping of variable names to new values.
+        new_file_path (str): Path to write the updated configuration file.
 
     Returns:
         None
 
     """
+    logger = setup_logger()
     flat_variables_dict = {convert_to_flatcase(k): v for k, v in variables_dict.items()}
 
     with Path(file_path).open() as file:
@@ -164,6 +110,9 @@ def replace_file_variables(
     new_lines = []
     for line in lines:
         stripped_line = line.rstrip()
+
+        if "return" in stripped_line:
+            line = line.replace("return", "SandboxVars =")
 
         if not is_line_valid(stripped_line):
             new_lines.append(line)
@@ -174,7 +123,10 @@ def replace_file_variables(
             pre_key, key, separator, old_value, post_value = match.groups()
             flat_key = convert_to_flatcase(key)
 
-            if flat_key in flat_variables_dict:
+            if (
+                flat_key in flat_variables_dict
+                and flat_variables_dict[flat_key] != old_value
+            ):
                 new_value = flat_variables_dict[flat_key]
                 updated_line = f"{pre_key}{key}{separator}{new_value}{post_value}\n"
                 logger.info(
@@ -189,59 +141,6 @@ def replace_file_variables(
         else:
             new_lines.append(line)
 
-    new_file_path = file_path.replace("servertest", server_name)
-    logger.info("Writing updated configuration to '%s'.", new_file_path)
-
+    Path(new_file_path).parent.mkdir(parents=True, exist_ok=True)
     with Path(new_file_path).open("w") as file:
         file.writelines(new_lines)
-
-
-def update_server_config(config_path: str, variables: dict) -> None:
-    """Update the server configuration file with the provided variables.
-
-    Args:
-        config_path: Path to the server configuration file.
-        variables: Variables to replace in the config file.
-
-    """
-    server_name = variables["SERVER_NAME"]
-    default_vars = load_variables(config_path)
-    custom_vars = extract_differential_values(variables, default_vars)
-    logger.info(
-        "Found %d custom variables to update in the config file.",
-        len(custom_vars),
-    )
-
-    replace_file_variables(config_path, custom_vars, server_name)
-
-
-def update_server_sandbox_config(
-    sandbox_path: str,
-    variables: dict,
-    preset_path: str | None = None,
-) -> None:
-    """Update the server sandbox configuration file with the provided variables.
-
-    Args:
-        sandbox_path: Path to the sandbox configuration file.
-        variables: Variables to replace in the sandbox file.
-        preset_path: Optional path to a preset file.
-
-    """
-    server_name = variables["SERVER_NAME"]
-    default_vars = load_variables(sandbox_path)
-    custom_vars = extract_differential_values(variables, default_vars)
-    logger.info(
-        "Found %d custom variables to update in the sandbox file.",
-        len(custom_vars),
-    )
-
-    if preset_path:
-        logger.info("Applying preset '%s' to sandbox configuration.", preset_path)
-        preset_vars = load_variables(preset_path)
-        preset_diff = extract_differential_values(preset_vars, default_vars)
-        logger.info("Found %d preset variables to apply.", len(preset_diff))
-
-        custom_vars = {**preset_diff, **custom_vars}
-
-    replace_file_variables(sandbox_path, custom_vars, server_name)

--- a/zomboid-server/scripts/setup/update_server_config.py
+++ b/zomboid-server/scripts/setup/update_server_config.py
@@ -1,39 +1,62 @@
-import logging
-import sys
 from pathlib import Path
 
-from helpers import load_variables, update_server_config, update_server_sandbox_config
+from helpers import load_custom_variables, rewrite_file_variables, setup_logger
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
-if not logger.hasHandlers():
-    handler = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter("%(levelname)s: %(message)s")
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
+def main() -> None:
+    """Set up and update the server configuration.
 
-if __name__ == "__main__":
-    env_vars = load_variables()
+    This function loads environment variables, determines the appropriate configuration
+    and sandbox files, applies any selected presets, and rewrites the configuration
+    files with the updated variables.
+    """
+    logger = setup_logger()
+    env_vars = load_custom_variables()
 
     cache_dir = env_vars["CACHE_DIR"]
+    presets_dir = env_vars["PRESETS_DIR"]
+    defaults_dir = env_vars["DEFAULTS_DIR"]
     selected_preset = env_vars["SERVER_PRESET"]
     server_name = env_vars["SERVER_NAME"]
-    presets_dir = env_vars["PRESETS_DIR"]
 
-    default_config_file = f"{cache_dir}/Server/servertest.ini"
-    default_sandbox_file = f"{cache_dir}/Server/servertest_SandboxVars.lua"
+    default_config_file = Path(defaults_dir) / "default.ini"
+    default_sandbox_file = Path(defaults_dir) / "default_SandboxVars.lua"
+    current_config_file = Path(cache_dir) / "Server" / f"{server_name}.ini"
+    current_sandbox_file = Path(cache_dir) / "Server" / f"{server_name}_SandboxVars.lua"
+    preset_file = (
+        Path(presets_dir) / f"{selected_preset}.lua" if selected_preset else None
+    )
 
-    preset_file = f"{presets_dir}/{selected_preset}.lua" if selected_preset else None
+    if current_config_file.exists():
+        logger.info("Using current config file for %s.", server_name)
+        default_config_file = current_config_file
 
-    if preset_file and not Path(preset_file).is_file():
-        logger.error("Preset file '%s' does not exist.", preset_file)
-        preset_file = None
+    if current_sandbox_file.exists():
+        logger.info("Using current sandbox file for %s.", server_name)
+        default_sandbox_file = current_sandbox_file
 
-    logger.info("Updating server configuration for '%s'.", server_name)
-    update_server_config(default_config_file, env_vars)
+    if preset_file and preset_file.exists():
+        logger.info("Sandbox config overridden by preset: %s", selected_preset)
+        default_sandbox_file = preset_file
 
-    logger.info("-" * 60)
+    elif preset_file and not preset_file.exists():
+        logger.error(
+            'Preset file "%s" does not exist, make sure to select a valid preset name',
+            selected_preset,
+        )
 
-    logger.info("Updating server sandbox configuration for '%s'.", server_name)
-    update_server_sandbox_config(default_sandbox_file, env_vars, preset_file)
+    rewrite_file_variables(
+        file_path=str(default_config_file),
+        variables_dict=env_vars,
+        new_file_path=str(current_config_file),
+    )
+
+    rewrite_file_variables(
+        file_path=str(default_sandbox_file),
+        variables_dict=env_vars,
+        new_file_path=str(current_sandbox_file),
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request adds support for a new `/defaults` directory in the Zomboid server Docker image and associated environment scripts. The main goal is to simplify the use of configuration presets and enable easy customization through environment variables.

### Key changes:

#### Docker image:

* Added `COPY --from=build /defaults /defaults` to the Dockerfile to include the new default configuration directory in the runtime image.

#### ⚙️ Environment configuration:

* Introduced the `DEFAULTS_DIR` variable in `server-init-flags.sh` (default: `/defaults`) to reference the new directory.
* Updated the initialization logic to:

  1. Use the files in `/defaults` as base templates for server configuration.
  2. If a preset is selected, it will override the base default file.
  3. Finally, variables in the selected configuration file are replaced dynamically using Python scripts.

#### Misc:

* To clearly identify which environment variables are left unset or require user input, the default value of shell variables was changed to `custom-not-set`.
