### PR TITLE
fix: update default values for server init flags

### DIFF
--- a/zomboid-server/env/docs/server-init-flags.md
+++ b/zomboid-server/env/docs/server-init-flags.md
@@ -55,11 +55,12 @@ The following table shows all variables you can override, their purpose, and def
 | `DEBUG`          | Enable debug mode for verbose logging (0=False, 1=True)    | `0`                                      |
 | `ADMIN_USERNAME` | Default administrator username                             | `admin`                                  |
 | `ADMIN_PASSWORD` | Default administrator password                             | `admin`                                  |
-| `IP`             | IP address for the server to bind to                       | `0.0.0.0`                                |
+| `IP`             | IP address for the server to bind to                       | _(empty)_                                |
 | `PORT`           | Primary server port for client connections                 | `16261`                                  |
 | `STEAM_VAC`      | Enable Steam VAC (Valve Anti-Cheat)                        | `true`                                   |
 | `STEAM_PORT_1`   | First Steam communication port                             | _(empty)_                                |
 | `STEAM_PORT_2`   | Second Steam communication port                            | _(empty)_                                |
+| `MODFOLDERS`     | Comma-separated list of mod folder names                   | `steam,mods,workshop`                    |
 
 ## Most Common Variables to Change
 

--- a/zomboid-server/env/server-init-flags.sh
+++ b/zomboid-server/env/server-init-flags.sh
@@ -37,11 +37,12 @@ CACHE_DIR="${CACHE_DIR:-/root/Zomboid}"
 DEBUG="${DEBUG:-0}" # 0 = False, 1 = True
 ADMIN_USERNAME="${ADMIN_USERNAME:-admin}"
 ADMIN_PASSWORD="${ADMIN_PASSWORD:-admin}"
-IP="${IP:-0.0.0.0}"
+IP="${IP:-}"
 PORT="${PORT:-16261}"
 STEAM_VAC="${STEAM_VAC:-true}"
 STEAM_PORT_1="${STEAM_PORT_1:-}"
 STEAM_PORT_2="${STEAM_PORT_2:-}"
 
+MODFOLDERS="${MODFOLDERS:-steam,mods,workshop}"
 # Disable automatic export
 set +a

--- a/zomboid-server/env/server-init-settings.sh
+++ b/zomboid-server/env/server-init-settings.sh
@@ -177,10 +177,10 @@ KICK_FAST_PLAYERS="${KICK_FAST_PLAYERS:-not-custom-set}"
 SERVER_PLAYER_ID="${SERVER_PLAYER_ID:-not-custom-set}"
 
 # The port for the RCON (Remote Console)
-RCON_PORT="${RCON_PORT:-not-custom-set}"
+RCON_PORT="${RCON_PORT:-27015}"
 
 # RCON password (Pick a strong password)
-RCON_PASSWORD="${RCON_PASSWORD:-not-custom-set}"
+RCON_PASSWORD="${RCON_PASSWORD:-admin}"
 
 # Enables global text chat integration with a Discord channel
 DISCORD_ENABLE="${DISCORD_ENABLE:-not-custom-set}"

--- a/zomboid-server/scripts/entrypoint.sh
+++ b/zomboid-server/scripts/entrypoint.sh
@@ -27,6 +27,8 @@ if [[ -z "${HAS_CONTENTS}" ]]; then
 	cp -r /zomboid-data/. "${CACHE_DIR}/"
 fi
 
+chmod -R 777 "${CACHE_DIR}"
+
 # Update server configuration for custom settings
 if [[ -f "${SERVER_CONFIG_UPDATE_SCRIPT}" ]]; then
 	(cd "${DIR}/setup" && python3 update_server_config.py)

--- a/zomboid-server/scripts/init-server.sh
+++ b/zomboid-server/scripts/init-server.sh
@@ -15,34 +15,35 @@ set -eo pipefail
 START_SCRIPT="${SERVER_DIR}/start-server.sh"
 
 # Argument array for the server start command
-ARGS=()
+ARGS=""
 
 # Java args
-[[ -n "${SERVER_MEMORY}" ]] && ARGS+=("-Xmx${SERVER_MEMORY}" "-Xms${SERVER_MEMORY}")
-[[ "${SOFTRESET,,}" =~ ^(1|true)$ ]] && ARGS+=("-Dsoftreset")
-ARGS+=("--")
+[[ -n "${SERVER_MEMORY}" ]] && ARGS+=" -Xmx${SERVER_MEMORY} -Xms${SERVER_MEMORY}"
+[[ "${SOFTRESET,,}" =~ ^(1|true)$ ]] && ARGS+=" -Dsoftreset"
+ARGS+=" --"
 
 # Config args
-[[ "${COOP_SERVER,,}" =~ ^(1|true)$ ]] && ARGS+=("-coop")
-[[ "${NO_STEAM,,}" =~ ^(1|true)$ ]] && ARGS+=("-nosteam")
-[[ -n "${CACHE_DIR}" ]] && ARGS+=("-cachedir" "${CACHE_DIR}")
-[[ "${DEBUG,,}" =~ ^(1|true)$ ]] && ARGS+=("-debug")
-[[ -n "${ADMIN_USERNAME}" ]] && ARGS+=("-adminusername" "${ADMIN_USERNAME}")
-[[ -n "${ADMIN_PASSWORD}" ]] && ARGS+=("-adminpassword" "${ADMIN_PASSWORD}")
+[[ -n "${MODFOLDERS}" ]] && ARGS+=" -modfolders ${MODFOLDERS}"
+[[ "${COOP_SERVER,,}" =~ ^(1|true)$ ]] && ARGS+=" -coop"
+[[ "${NO_STEAM,,}" =~ ^(1|true)$ ]] && ARGS+=" -nosteam"
+[[ -n "${CACHE_DIR}" ]] && ARGS+=" -cachedir=${CACHE_DIR}"
+[[ "${DEBUG,,}" =~ ^(1|true)$ ]] && ARGS+=" -debug"
+[[ -n "${ADMIN_USERNAME}" ]] && ARGS+=" -adminusername ${ADMIN_USERNAME}"
+[[ -n "${ADMIN_PASSWORD}" ]] && ARGS+=" -adminpassword ${ADMIN_PASSWORD}"
 if [[ -n "${SERVER_NAME}" ]]; then
 	SERVER_NAME="${SERVER_NAME// /-}"
-	ARGS+=("-servername" "${SERVER_NAME}")
+	ARGS+=" -servername ${SERVER_NAME}"
 fi
-[[ -n "${IP}" ]] && ARGS+=("${IP} -ip" "${IP}")
-[[ -n "${PORT}" ]] && ARGS+=("-port" "${PORT}")
-[[ -n "${STEAM_VAC}" ]] && ARGS+=("-steamvac" "${STEAM_VAC,,}")
-[[ -n "${STEAM_PORT_1}" ]] && ARGS+=("-steamport1" "${STEAM_PORT_1}")
-[[ -n "${STEAM_PORT_2}" ]] && ARGS+=("-steamport2" "${STEAM_PORT_2}")
+[[ -n "${IP}" ]] && ARGS+=" -ip ${IP}"
+[[ -n "${PORT}" ]] && ARGS+=" -port ${PORT}"
+[[ -n "${STEAM_VAC}" ]] && ARGS+=" -steamvac ${STEAM_VAC,,}"
+[[ -n "${STEAM_PORT_1}" ]] && ARGS+=" -steamport1 ${STEAM_PORT_1}"
+[[ -n "${STEAM_PORT_2}" ]] && ARGS+=" -steamport2 ${STEAM_PORT_2}"
 
 # Definición de entorno para Java
 export LD_LIBRARY_PATH="${SERVER_DIR}/jre64/lib:${LD_LIBRARY_PATH:-}"
 export LANG="${LANG:-en_US.UTF-8}"
 
 # Ejecuta el script de inicio del servidor
-echo "Starting Project Zomboid server with arguments: ${ARGS[*]}"
-exec "${START_SCRIPT}" "${ARGS[@]}"
+echo "Starting Project Zomboid server with arguments:${ARGS}"
+exec "${START_SCRIPT}" "${ARGS}"


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the Zomboid server initialization scripts and documentation. The main changes focus on better handling of environment variables, improved argument construction for server startup, and enhanced permissions for the server cache directory. These updates aim to make server configuration more flexible and robust.

**Environment variable defaults and documentation updates:**

* Changed the default value of the `IP` environment variable from `0.0.0.0` to empty, allowing more explicit control over binding behavior in both documentation (`server-init-flags.md`) and script (`server-init-flags.sh`). [[1]](diffhunk://#diff-538bac8cdca5a3036f6f1d4a169264b456cb9ce807229c43df4c2c1947cd85f1L58-R63) [[2]](diffhunk://#diff-b91e836b0dceb4c232a297f09fc3e7fba517dfc2ef8751f01968c477611cd6dfL40-R46)
* Added a new `MODFOLDERS` environment variable with a default value of `steam,mods,workshop` to support specifying mod folder names in both documentation and script. [[1]](diffhunk://#diff-538bac8cdca5a3036f6f1d4a169264b456cb9ce807229c43df4c2c1947cd85f1L58-R63) [[2]](diffhunk://#diff-b91e836b0dceb4c232a297f09fc3e7fba517dfc2ef8751f01968c477611cd6dfL40-R46)
* Set explicit defaults for RCON-related environment variables: `RCON_PORT` now defaults to `27015` and `RCON_PASSWORD` to `admin` in `server-init-settings.sh`.

**Server startup and permissions:**

* Updated `init-server.sh` to construct the server argument string (`ARGS`) as a single string instead of an array, simplifying the handling of environment variables and supporting the new `MODFOLDERS` argument.
* Added a step in `entrypoint.sh` to set permissions of the cache directory (`CACHE_DIR`) to `777`, ensuring the server has full access to its data.