### PR TITLE
fix: server init arguments bad formatted

### DIFF
--- a/zomboid-server/scripts/init-server.sh
+++ b/zomboid-server/scripts/init-server.sh
@@ -14,36 +14,38 @@ set -eo pipefail
 
 START_SCRIPT="${SERVER_DIR}/start-server.sh"
 
-# Argument array for the server start command
-ARGS=""
+declare -a ARGS=()
 
-# Java args
-[[ -n "${SERVER_MEMORY}" ]] && ARGS+=" -Xmx${SERVER_MEMORY} -Xms${SERVER_MEMORY}"
-[[ "${SOFTRESET,,}" =~ ^(1|true)$ ]] && ARGS+=" -Dsoftreset"
-ARGS+=" --"
+# JVM args
+if [[ -n "${SERVER_MEMORY}" ]]; then
+	ARGS+=("-Xmx${SERVER_MEMORY}" "-Xms${SERVER_MEMORY}")
+fi
+[[ "${SOFTRESET,,}" =~ ^(1|true)$ ]] && ARGS+=("-Dsoftreset")
 
-# Config args
-[[ -n "${MODFOLDERS}" ]] && ARGS+=" -modfolders ${MODFOLDERS}"
-[[ "${COOP_SERVER,,}" =~ ^(1|true)$ ]] && ARGS+=" -coop"
-[[ "${NO_STEAM,,}" =~ ^(1|true)$ ]] && ARGS+=" -nosteam"
-[[ -n "${CACHE_DIR}" ]] && ARGS+=" -cachedir=${CACHE_DIR}"
-[[ "${DEBUG,,}" =~ ^(1|true)$ ]] && ARGS+=" -debug"
-[[ -n "${ADMIN_USERNAME}" ]] && ARGS+=" -adminusername ${ADMIN_USERNAME}"
-[[ -n "${ADMIN_PASSWORD}" ]] && ARGS+=" -adminpassword ${ADMIN_PASSWORD}"
+ARGS+=("--")
+
+# Server args
+[[ -n "${MODFOLDERS}" ]] && ARGS+=("-modfolders" "${MODFOLDERS}")
+[[ "${COOP_SERVER,,}" =~ ^(1|true)$ ]] && ARGS+=("-coop")
+[[ "${NO_STEAM,,}" =~ ^(1|true)$ ]] && ARGS+=("-nosteam")
+[[ -n "${CACHE_DIR}" ]] && ARGS+=("-cachedir=${CACHE_DIR}")
+[[ "${DEBUG,,}" =~ ^(1|true)$ ]] && ARGS+=("-debug")
+[[ -n "${ADMIN_USERNAME}" ]] && ARGS+=("-adminusername" "${ADMIN_USERNAME}")
+[[ -n "${ADMIN_PASSWORD}" ]] && ARGS+=("-adminpassword" "${ADMIN_PASSWORD}")
+
 if [[ -n "${SERVER_NAME}" ]]; then
 	SERVER_NAME="${SERVER_NAME// /-}"
-	ARGS+=" -servername ${SERVER_NAME}"
+	ARGS+=("-servername" "${SERVER_NAME}")
 fi
-[[ -n "${IP}" ]] && ARGS+=" -ip ${IP}"
-[[ -n "${PORT}" ]] && ARGS+=" -port ${PORT}"
-[[ -n "${STEAM_VAC}" ]] && ARGS+=" -steamvac ${STEAM_VAC,,}"
-[[ -n "${STEAM_PORT_1}" ]] && ARGS+=" -steamport1 ${STEAM_PORT_1}"
-[[ -n "${STEAM_PORT_2}" ]] && ARGS+=" -steamport2 ${STEAM_PORT_2}"
 
-# Definición de entorno para Java
+[[ -n "${IP}" ]] && ARGS+=("-ip" "${IP}")
+[[ -n "${PORT}" ]] && ARGS+=("-port" "${PORT}")
+[[ -n "${STEAM_VAC}" ]] && ARGS+=("-steamvac" "${STEAM_VAC,,}")
+[[ -n "${STEAM_PORT_1}" ]] && ARGS+=("-steamport1" "${STEAM_PORT_1}")
+[[ -n "${STEAM_PORT_2}" ]] && ARGS+=("-steamport2" "${STEAM_PORT_2}")
+
 export LD_LIBRARY_PATH="${SERVER_DIR}/jre64/lib:${LD_LIBRARY_PATH:-}"
 export LANG="${LANG:-en_US.UTF-8}"
 
-# Ejecuta el script de inicio del servidor
-echo "Starting Project Zomboid server with arguments:${ARGS}"
-exec "${START_SCRIPT}" "${ARGS}"
+echo "Starting Project Zomboid server with arguments: ${ARGS[*]}"
+exec "${START_SCRIPT}" "${ARGS[@]}"


### PR DESCRIPTION
This pull request refactors how command-line arguments are built and passed to the server start script in `init-server.sh`. The main improvement is switching from a string-based approach to using a Bash array for argument handling, which makes the script more robust and less error-prone, especially when dealing with arguments that contain spaces or special characters.

**Argument handling improvements:**

* Replaces string concatenation for building the `ARGS` variable with a Bash array (`declare -a ARGS=()`), ensuring safer and more reliable handling of command-line arguments.
* Updates the way arguments are appended throughout the script to use array syntax (`ARGS+=(...)`), and changes the final execution to pass arguments as an array (`"${ARGS[@]}"`) instead of a single string.

**Output and execution changes:**

* Modifies the echo statement to properly display the list of arguments using array expansion (`${ARGS[*]}`) for better readability in logs.
* Ensures the server start script is executed with each argument as a separate parameter, reducing the risk of parsing errors.