### PR TITLE
fix: remove unnecessary build cache logic

### DIFF
--- a/zomboid-server/Dockerfile
+++ b/zomboid-server/Dockerfile
@@ -23,7 +23,6 @@ COPY ./scripts /scripts
 
 RUN chmod -R a+x /scripts \
     && /scripts/build/generate-defaults.sh \
-    && /scripts/build/install-admin-console.sh \
-    && cp -r /pzomboid-server /root/Zomboid
+    && /scripts/build/install-admin-console.sh
 
 ENTRYPOINT ["bash", "/scripts/entrypoint.sh"]

--- a/zomboid-server/scripts/entrypoint.sh
+++ b/zomboid-server/scripts/entrypoint.sh
@@ -21,12 +21,6 @@ else
 	exit 1
 fi
 
-mkdir -p "${CACHE_DIR}"
-HAS_CONTENTS=$(ls -A "${CACHE_DIR}" 2>/dev/null || true)
-if [[ -z "${HAS_CONTENTS}" ]]; then
-	cp -r /zomboid-data/. "${CACHE_DIR}/"
-fi
-
 chmod -R 777 "${CACHE_DIR}"
 
 # Update server configuration for custom settings


### PR DESCRIPTION
## Description
This pull request makes minor adjustments to the server initialization process, specifically focusing on the handling of the cache directory and Docker image setup.

Improvements to Docker build process:

* In `zomboid-server/Dockerfile`, the step that copied `/pzomboid-server` to `/root/Zomboid` after installing the admin console was removed, it made no sense.

Cache directory handling simplification:

* In `zomboid-server/scripts/entrypoint.sh`, the logic for checking and populating the cache directory from `/zomboid-data` if it was empty was removed, as now we dont use a multi steps build.