### PR TITLE
feat: add version extraction script at build

### DIFF
--- a/zomboid-server/Dockerfile
+++ b/zomboid-server/Dockerfile
@@ -23,6 +23,8 @@ COPY ./scripts /scripts
 
 RUN chmod -R a+x /scripts \
     && /scripts/build/generate-defaults.sh \
-    && /scripts/build/install-admin-console.sh
+    && /scripts/build/install-admin-console.sh \
+    && PZ_VERSION=$(/scripts/build/find_server_version.sh || echo failed-to-retreive) \
+    && echo "${PZ_VERSION}" > /PZ_VERSION
 
 ENTRYPOINT ["bash", "/scripts/entrypoint.sh"]

--- a/zomboid-server/scripts/build/find_server_version.sh
+++ b/zomboid-server/scripts/build/find_server_version.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# find_server_version.sh - Build-time Project Zomboid version extractor
+#
+# Minimal script used ONLY during Docker build. It reads the server console log
+# located at ${CACHE_DIR:-/root/Zomboid}/server-console.txt, finds the first
+# occurrence of the token: version=XX(.YY)* and prints ONLY the numeric version
+# to STDOUT. No exporting, no sourcing semantics—just plain output so the
+# Dockerfile can capture it and persist it (e.g. into a file layer).
+#
+# Exit codes:
+#   0  success
+#   1  log file missing
+#   2  version pattern not found
+
+set -euo pipefail
+
+CACHE_DIR="${CACHE_DIR:-/root/Zomboid}"
+LOG_FILE="${CACHE_DIR}/server-console.txt"
+
+if [[ ! -f "${LOG_FILE}" ]]; then
+	echo "Error: log file not found: ${LOG_FILE}" >&2
+	exit 1
+fi
+
+# Extract the first occurrence of version=... capturing only the value
+if ! VERSION_LINE=$(grep -m1 -E 'version=[0-9]+(\.[0-9]+)*' "${LOG_FILE}" || true); then
+	VERSION_LINE=""
+fi
+
+if [[ -z "${VERSION_LINE}" ]]; then
+	echo "Error: version pattern not found in log file" >&2
+	exit 2
+fi
+
+# Use parameter expansion to isolate the version token
+VERSION_PART=${VERSION_LINE#*version=}
+PROJECT_ZOMBOID_VERSION=${VERSION_PART%% *}
+
+echo -n "${PROJECT_ZOMBOID_VERSION}"

--- a/zomboid-server/scripts/server-init-flags.sh
+++ b/zomboid-server/scripts/server-init-flags.sh
@@ -48,5 +48,10 @@ RCON_PORT="${RCON_PORT:-27015}"
 RCON_PASSWORD="${RCON_PASSWORD:-admin}"
 
 MODFOLDERS="${MODFOLDERS:-steam,mods,workshop}"
+
+if [[ -z "${PZ_VERSION:-}" && -f /PZ_VERSION ]]; then
+	PZ_VERSION="$(cat /PZ_VERSION 2>/dev/null || echo unknown)"
+fi
+
 # Disable automatic export
 set +a


### PR DESCRIPTION
## Description
This pull request adds functionality to extract and persist the Project Zomboid server version during Docker image build, and makes this version available at runtime for scripts. The main changes include a new script to extract the version, updates to the Dockerfile to use this script and save the version, and logic in the server initialization script to read and expose the version if available.

**Build-time version extraction and persistence:**

* Added `find_server_version.sh` script to extract the Project Zomboid version from the server console log during Docker build, outputting only the numeric version for use in other steps.
* Updated `zomboid-server/Dockerfile` to run the new script during build and save the extracted version to `/PZ_VERSION` for later use.

**Runtime version availability:**

* Modified `server-init-flags.sh` to read the `/PZ_VERSION` file and set the `PZ_VERSION` environment variable if not already set, ensuring the version is accessible to runtime scripts.