### PR TITLE
refactor: rename server-init-flags to server-base-variables

### DIFF
--- a/zomboid-server/scripts/entrypoint.sh
+++ b/zomboid-server/scripts/entrypoint.sh
@@ -8,16 +8,16 @@
 # and starts the Project Zomboid server using the final configuration.
 
 DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
-FLAGS_SCRIPT="${DIR}/server-init-flags.sh"
+BASE_VARIABLES_SCRIPT="${DIR}/server-base-variables.sh"
 SERVER_INIT_SCRIPT="${DIR}/init-server.sh"
 SERVER_CONFIG_UPDATE_SCRIPT="${DIR}/config/main.py"
 
-# Source server start flags vars
-if [[ -f "${FLAGS_SCRIPT}" ]]; then
-	# shellcheck source=server-init-flags.sh
-	source "${FLAGS_SCRIPT}"
+# Source server base variables
+if [[ -f "${BASE_VARIABLES_SCRIPT}" ]]; then
+	# shellcheck source=server-base-variables.sh
+	source "${BASE_VARIABLES_SCRIPT}"
 else
-	echo "Error: Server init flags script not found: ${FLAGS_SCRIPT}"
+	echo "Error: Server base variables script not found: ${BASE_VARIABLES_SCRIPT}"
 	exit 1
 fi
 

--- a/zomboid-server/scripts/server-base-variables.sh
+++ b/zomboid-server/scripts/server-base-variables.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Project Zomboid Server Argument Flags
+# Project Zomboid Server base environment variables
 #
 # This script defines default environment variables for the Project Zomboid
 # dedicated server startup script (start-server.sh). These variables can
@@ -8,13 +8,13 @@
 #
 # Usage:
 #   Source this file before running start-server.sh:
-#   source ./server-init-flags.sh
+#   source ./server-base-variables.sh
 #   ./start-server.sh
 #
 # Docker Usage:
 #   Override any variable using Docker's -e flag:
 #   docker run -e SERVER_NAME="MyServer" -e PORT="16262" <image>
-
+#
 # Enable automatic export of all variables
 set -a
 
@@ -43,12 +43,13 @@ PORT="${PORT:-16261}"
 STEAM_VAC="${STEAM_VAC:-true}"
 STEAM_PORT_1="${STEAM_PORT_1:-}"
 STEAM_PORT_2="${STEAM_PORT_2:-}"
+MODFOLDERS="${MODFOLDERS:-steam,mods,workshop}"
 
+# Remote console (RCON) settings
 RCON_PORT="${RCON_PORT:-27015}"
 RCON_PASSWORD="${RCON_PASSWORD:-admin}"
 
-MODFOLDERS="${MODFOLDERS:-steam,mods,workshop}"
-
+# Set Project Zomboid version if available
 if [[ -z "${PZ_VERSION:-}" && -f /PZ_VERSION ]]; then
 	PZ_VERSION="$(cat /PZ_VERSION 2>/dev/null || echo unknown)"
 fi


### PR DESCRIPTION
## Description
This pull request refactors the server startup scripts for the Project Zomboid server to improve clarity and maintainability. The main changes involve renaming the environment variable script for better accuracy and updating references throughout the codebase. Additionally, minor adjustments were made to the structure and comments of the environment variable definitions.

**Script refactoring and renaming:**

* Renamed `server-init-flags.sh` to `server-base-variables.sh` to better reflect its purpose as a source of environment variables, and updated all references and documentation comments to use the new name. [[1]](diffhunk://#diff-0444dbb62de933d1818ee66235e5a4c681b181f899f1a9eb121a85bf4c07c5b0L2-R2) [[2]](diffhunk://#diff-0444dbb62de933d1818ee66235e5a4c681b181f899f1a9eb121a85bf4c07c5b0L11-R17) [[3]](diffhunk://#diff-7689961879630acceda8903d873f15f7e46232ee956d92b65111bb98f3cdcc9aL11-R20)

**Environment variable definitions:**

* Moved the definition of the `MODFOLDERS` variable to group it more logically with related settings, and added a comment header for RCON (remote console) settings to improve readability.