### PR TITLE
docs: update README and configuration files for clarity

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,12 +9,11 @@ services:
       - ${LOCAL_WORKSPACE_FOLDER:-.}/workshop:/root/.local/share/Steam/steamapps/workshop
       - ${LOCAL_WORKSPACE_FOLDER:-.}/zomboid-server/scripts:/scripts
     ports:
-      - 16261:16261/udp # Port for the server
-      - 16261:16261/tcp # TCP port for the server
-      - 8766:8766/udp # Steam query port
-      - 16262-16272:16262-16272/udp # Direct connection ports
+      - 16261:16261/udp
+      - 16262:16262/udp
+      - 27015:27015 # For RCON outside the container
     environment:
       - PVP=false
       - ZOMBIES=5
       - DAY_LENGTH=5
-      - SERVER_NAME=meshi-test-3
+      - SERVER_NAME=meshi-test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       - ./data:/root/Zomboid
       - ./workshop:/root/.local/share/Steam/steamapps/workshop
     ports:
-      - 16261:16261/udp # Port for the server
-      - 16261:16261/tcp # TCP port for the server
-      - 8766:8766/udp # Steam query port
-      - 16262-16272:16262-16272/udp # Direct connection ports
+      - 16261:16261/udp
+      - 16262:16262/udp
+      - 27015:27015 # For RCON outside the container

--- a/docs/server_customization/1-server-base-variables-and-flags.md
+++ b/docs/server_customization/1-server-base-variables-and-flags.md
@@ -6,17 +6,6 @@ This document lists all the environment variables you can customize when running
 
 **All variables listed below can be customized using Docker's `-e` flag.**
 
-## Table of Contents
-
-- [Description](#description)
-- [Table of Contents](#table-of-contents)
-- [How to Override Variables](#how-to-override-variables)
-- [Available Configuration Variables](#available-configuration-variables)
-- [Most Common Variables to Change](#most-common-variables-to-change)
-- [Quick Reference](#quick-reference)
-  - [Boolean Values](#boolean-values)
-  - [Memory Values](#memory-values)
-
 ## How to Override Variables
 
 Use Docker Compose and add your variables under the `environment:` key:

--- a/docs/server_customization/2-server-general-config.md
+++ b/docs/server_customization/2-server-general-config.md
@@ -6,19 +6,6 @@ This document lists all the environment variables you can customize for Project 
 
 **All variables listed below can be customized using Docker's `-e` flag.**
 
-## Table of Contents
-
-- [Description](#description)
-- [Table of Contents](#table-of-contents)
-- [How to Override Variables](#how-to-override-variables)
-- [Available Configuration Variables](#available-configuration-variables)
-- [Anti-Cheat Protection Variables](#anti-cheat-protection-variables)
-- [Most Common Variables to Change](#most-common-variables-to-change)
-- [Quick Reference](#quick-reference)
-  - [Boolean Values](#boolean-values)
-  - [Numeric Values](#numeric-values)
-  - [Special Formats](#special-formats)
-
 ## How to Override Variables
 
 Use Docker Compose and add your variables under the `environment:` key:

--- a/docs/server_customization/3-server-sandbox-vars.md
+++ b/docs/server_customization/3-server-sandbox-vars.md
@@ -6,19 +6,6 @@ This document lists all the environment variables you can customize for Project 
 
 **All variables listed below can be customized using Docker's `-e` flag.**
 
-## Table of Contents
-
-- [Description](#description)
-- [Table of Contents](#table-of-contents)
-- [How to Override Variables](#how-to-override-variables)
-- [Available Configuration Variables](#available-configuration-variables)
-- [Most Common Variables to Change](#most-common-variables-to-change)
-- [Quick Reference](#quick-reference)
-  - [Numeric Options](#numeric-options)
-  - [Boolean Values](#boolean-values)
-  - [Multiplier Values](#multiplier-values)
-  - [Time Values](#time-values)
-
 ## How to Override Variables
 
 Use Docker Compose and add your variables under the `environment:` key:
@@ -41,8 +28,6 @@ services:
 ## Available Configuration Variables
 
 The following table shows all variables you can override, their purpose, and default values:
-
-> **💡 Tip**: For more complete descriptions of available values and detailed explanations, refer to the original `server-sandbox-vars.sh` file which contains extensive comments for each setting.
 
 | Variable Name                        | Description                                                                                             | Default Value                          |
 | ------------------------------------ | ------------------------------------------------------------------------------------------------------- | -------------------------------------- |


### PR DESCRIPTION
This pull request updates documentation and configuration files to simplify setup instructions, clarify environment variable usage, and improve port and mod configuration for the Project Zomboid server. The changes focus on making the README more user-friendly, streamlining port mappings in Docker Compose files, and updating modding instructions.

**Documentation and Setup Improvements:**

* Refactored the `README.md` to provide clearer, step-by-step setup instructions, including simplified Docker Compose and `docker run` examples, and consolidated configuration guidance under "Environment variables." The configuration section now details all customizable environment variables, presets, and their application, making it easier for users to understand and override settings.
* Updated the modding section in `README.md` to clarify the roles of `WORKSHOP_ITEMS` and `MODS` environment variables, with improved examples and explanations of how mods and maps are loaded. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L235-R280) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L274-R299)

**Configuration and Port Mapping Updates:**

* Simplified port mappings in `docker-compose.yml` and `docker-compose.dev.yml` by removing unused ports and clearly documenting required and optional ports, including explicit mapping for RCON. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L11-R13) [[2]](diffhunk://#diff-9542f82d64bbeebd91f6236324bfe199e9657e2cb1fd9779d5d6dcdcf9cd4de1L12-R19)
* Removed redundant Table of Contents sections from the server customization documentation files for base variables, general config, and sandbox variables, making these docs more concise and focused. [[1]](diffhunk://#diff-b33be0a396d049ecf14b00ce2a6a3f6962c3433ccbb44cac9674aa99582bae02L9-L19) [[2]](diffhunk://#diff-bc84e26384cc3e520243f1aaba46bbb3141ac27116fb0ba56173f7a60d002e7aL9-L21) [[3]](diffhunk://#diff-07242bd3e471bad01f747658248fc290b20dadd5dcf05e303446f88c38fb642dL9-L21)

**Minor Documentation Cleanups:**

* Removed an outdated tip regarding value descriptions from the sandbox variables documentation for clarity.