### PR TITLE
fix: reliable steamcmd install and workshop downloads

### DIFF
--- a/zomboid-server/Dockerfile
+++ b/zomboid-server/Dockerfile
@@ -12,8 +12,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /pzomboid-server \
-    && steamcmd +login anonymous \
-    +force_install_dir /pzomboid-server \
+    && steamcmd +login anonymous +quit \
+    && steamcmd +force_install_dir /pzomboid-server \
+    +login anonymous \
     +app_update ${ZOMBOID_SERVER_APP_ID} validate \
     +quit
 

--- a/zomboid-server/scripts/config/workshop_manager.py
+++ b/zomboid-server/scripts/config/workshop_manager.py
@@ -109,6 +109,16 @@ class ProjectZomboidWorkshopManager:
         succeeded: set[str] = set()
         failed: set[str] = set()
 
+        pending = [wid for wid in self.server_workshop_items if wid not in downloaded]
+        if pending:
+            # Warm steamcmd's license cache; skipping this races `+workshop_download_item`.
+            subprocess.run(
+                ["steamcmd", "+login", "anonymous", "+quit"],  # noqa: S607
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
         for wid in self.server_workshop_items.copy():
             self.logger.info("-" * 40)
             self.logger.info("Processing workshop item: %s", wid)
@@ -118,8 +128,11 @@ class ProjectZomboidWorkshopManager:
                 continue
 
             self.logger.info("Downloading: %s", wid)
+            steam_root = str(Path(self.steam_workshop_folder).parent.parent)
             command = [
                 "steamcmd",
+                "+force_install_dir",
+                steam_root,
                 "+login",
                 "anonymous",
                 "+workshop_download_item",
@@ -200,11 +213,17 @@ class ProjectZomboidWorkshopManager:
         steam_wk_manifest = Path(self.steam_workshop_folder) / manifest_file
         server_wk_manifest = self.server_workshop_folder / manifest_file
 
-        if len(desired) == 0 and server_wk_manifest.exists():
-            self.logger.info("No workshop items selected, clearing manifest.")
-            server_wk_manifest.unlink()
-        else:
+        if len(desired) == 0:
+            if server_wk_manifest.exists():
+                self.logger.info("No workshop items selected, clearing manifest.")
+                server_wk_manifest.unlink()
+        elif steam_wk_manifest.exists():
             shutil.copy2(steam_wk_manifest, server_wk_manifest)
+        else:
+            self.logger.warning(
+                "Steam workshop manifest not found, skipping copy: %s",
+                steam_wk_manifest,
+            )
 
         self.logger.info("-" * 40)
         self.logger.info("Linking summary → linked:%d, errors:%d", linked, errors)

--- a/zomboid-server/scripts/entrypoint.sh
+++ b/zomboid-server/scripts/entrypoint.sh
@@ -21,6 +21,7 @@ else
 	exit 1
 fi
 
+mkdir -p "${CACHE_DIR}/mods"
 chmod -R 777 "${CACHE_DIR}"
 
 # Update server configuration for custom settings

--- a/zomboid-server/scripts/server-base-variables.sh
+++ b/zomboid-server/scripts/server-base-variables.sh
@@ -43,7 +43,7 @@ PORT="${PORT:-16261}"
 STEAM_VAC="${STEAM_VAC:-true}"
 STEAM_PORT_1="${STEAM_PORT_1:-}"
 STEAM_PORT_2="${STEAM_PORT_2:-}"
-MODFOLDERS="${MODFOLDERS:-steam,mods,workshop}"
+MODFOLDERS="${MODFOLDERS:-}"
 
 # Remote console (RCON) settings
 RCON_PORT="${RCON_PORT:-27015}"


### PR DESCRIPTION
## Summary

- **Dockerfile**: split the `steamcmd +app_update` into a two-phase call (`+login anonymous +quit` warm-up, then the real install). The original one-shot form hit an async race in non-interactive mode — `+login` returned `OK` before the account's license/app-info packets were indexed, so the immediately-queued `+app_update 380870` failed with `ERROR! Failed to install app '380870' (Missing configuration)` and killed the build.
- **workshop_manager.py (`download_workshop_items`)**: same warm-up applied before the per-item loop, plus `+force_install_dir <steam_root>` added (before `+login`) so downloads land on the bind-mounted `steamapps/workshop` subtree instead of steamcmd's default `/root/Steam/...` path that isn't persisted across restarts.
- **workshop_manager.py (manifest copy)**: fixed the vanilla (no-mods) case which crashed with `FileNotFoundError` trying to copy a nonexistent `appworkshop_108600.acf`. Now only copies when the source exists and only clears when there are zero desired items.
- **entrypoint.sh**: `mkdir -p "${CACHE_DIR}/mods"` so PZ's file watcher doesn't throw `NoSuchFileException: /root/Zomboid/mods` on startup.
- **server-base-variables.sh**: default `MODFOLDERS` to empty. The existing default `steam,mods,workshop` gets passed as `-modfolders steam,mods,workshop` to the launcher, which PZ build 41 doesn't recognize (`unknown option "-modfolders"`). The flag is a build 42 feature; users upgrading can still opt in via env.

## Test plan

- [x] `docker compose build --no-cache zomboid-server` completes (server install downloads the full ~5 GB)
- [x] Vanilla run (no `WORKSHOP_ITEMS`, no `MODS`) starts without the `appworkshop_108600.acf` traceback
- [x] With `WORKSHOP_ITEMS=522891356;2875848298` and `MODS=BedfordFalls;BB_CommonSense`, both workshop items download to `./workshop/content/108600/<id>/`, symlinks resolve, and both mods log `Active: True` then `loading <ModID>`
- [x] Auto-map integration: `Map=BedfordFalls;North;South;West;Muldraugh, KY` written to `servertest.ini`, spawnregions patched
- [x] Startup logs no longer show `unknown option "-modfolders"` or `NoSuchFileException: /root/Zomboid/mods`
- [x] `*** SERVER STARTED ****` and RCON listens on 27015; client connects to `localhost:16261`
