### PR TITLE
feat: add docker image release workflow

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,163 @@
+name: Release Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Build and probe only, skip push and tag
+        type: boolean
+        default: false
+
+env:
+  IMAGE_NAME: project-zomboid-server
+  BUILD_CONTEXT: zomboid-server
+
+jobs:
+  build-and-publish:
+    name: Build and publish image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Create meshi-team-bot[bot] token
+        id: bot-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.MESHI_TEAM_BOT_APP_ID }}
+          private-key: ${{ secrets.MESHI_TEAM_BOT_PRIVATE_KEY }}
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.bot-token.outputs.token }}
+
+      - name: Set build metadata
+        id: meta
+        shell: bash
+        run: |
+          echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+          echo "vcs_ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build candidate image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ env.BUILD_CONTEXT }}
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:candidate
+          build-args: |
+            BUILD_DATE=${{ steps.meta.outputs.build_date }}
+            VCS_REF=${{ steps.meta.outputs.vcs_ref }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Read PZ buildid
+        id: buildid
+        shell: bash
+        run: |
+          BUILDID=$(docker run --rm ${{ env.IMAGE_NAME }}:candidate cat /PZ_BUILD_ID)
+          if [[ -z "$BUILDID" ]]; then
+            echo "::error::Failed to read PZ_BUILD_ID"
+            exit 1
+          fi
+          echo "buildid=$BUILDID" >> "$GITHUB_OUTPUT"
+          echo "Detected Steam buildid: $BUILDID"
+
+      - name: Detect PZ semver via short server boot
+        id: semver
+        shell: bash
+        run: |
+          SEMVER=$(docker run --rm --entrypoint=bash \
+            ${{ env.IMAGE_NAME }}:candidate -c '
+              timeout 20 /pzomboid-server/start-server.sh \
+                -servername _probe -adminpassword x -cachedir=/tmp/probe 2>&1 \
+              | grep -m1 -oE "version=[0-9]+\.[0-9]+\.[0-9]+" \
+              | cut -d= -f2
+          ')
+          if [[ -z "$SEMVER" ]]; then
+            echo "::error::Failed to detect PZ semver from server boot"
+            exit 1
+          fi
+          echo "semver=$SEMVER" >> "$GITHUB_OUTPUT"
+          echo "Detected PZ semver: $SEMVER"
+
+      - name: Build and push final image
+        if: ${{ !inputs.dry_run }}
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ env.BUILD_CONTEXT }}
+          push: true
+          build-args: |
+            BUILD_DATE=${{ steps.meta.outputs.build_date }}
+            VCS_REF=${{ steps.meta.outputs.vcs_ref }}
+            PZ_VERSION=${{ steps.semver.outputs.semver }}
+            PZ_BUILD_ID=${{ steps.buildid.outputs.buildid }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.semver.outputs.semver }}
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ steps.semver.outputs.semver }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Sync Docker Hub description
+        if: ${{ !inputs.dry_run }}
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
+          readme-filepath: ./DOCKERHUB.md
+          short-description: >-
+            Project Zomboid dedicated server, ready to run with Steam
+            Workshop mods and RCON admin console.
+
+      - name: Create and push git tag
+        if: ${{ !inputs.dry_run }}
+        shell: bash
+        run: |
+          TAG="v${{ steps.semver.outputs.semver }}"
+          git tag "$TAG" "${{ github.sha }}" --force
+          git push origin "$TAG" --force
+          echo "Tagged $TAG at ${{ github.sha }}"
+
+      - name: Job summary
+        shell: bash
+        run: |
+          {
+            echo "## Release summary"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| PZ semver | \`${{ steps.semver.outputs.semver }}\` |"
+            echo "| Steam buildid | \`${{ steps.buildid.outputs.buildid }}\` |"
+            echo "| Git SHA | \`${{ github.sha }}\` |"
+            echo "| Dry run | \`${{ inputs.dry_run }}\` |"
+            echo ""
+            if [[ "${{ inputs.dry_run }}" != "true" ]]; then
+              GHCR="ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}"
+              DH="${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}"
+              SEMVER="${{ steps.semver.outputs.semver }}"
+              echo "### Published tags"
+              echo "- \`$GHCR:$SEMVER\`"
+              echo "- \`$GHCR:latest\`"
+              echo "- \`$DH:$SEMVER\`"
+              echo "- \`$DH:latest\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -1,0 +1,137 @@
+# Project Zomboid Dedicated Server
+
+Docker image for running a **Project Zomboid** dedicated server. Fully configurable via environment variables, with built-in Steam Workshop support, automatic map integration, and an RCON-powered admin console.
+
+- **Source**: https://github.com/meshi-team/project-zomboid-server
+- **Full documentation**: [README on GitHub](https://github.com/meshi-team/project-zomboid-server#readme)
+- **Issues**: https://github.com/meshi-team/project-zomboid-server/issues
+
+## Quick start
+
+### docker run
+
+```bash
+docker run -d \
+  --name zomboid-server \
+  -p 16261:16261/udp \
+  -p 16262:16262/udp \
+  -v $(pwd)/data:/root/Zomboid \
+  -v $(pwd)/workshop:/root/.local/share/Steam/steamapps/workshop \
+  -e SERVER_NAME=MyServer \
+  -e ADMIN_PASSWORD=change-me \
+  m4lagon/project-zomboid-server:latest
+```
+
+### docker compose
+
+```yaml
+services:
+  zomboid-server:
+    image: m4lagon/project-zomboid-server:latest
+    container_name: zomboid-server
+    ports:
+      - 16261:16261/udp
+      - 16262:16262/udp
+      - 27015:27015   # optional, for external RCON
+    volumes:
+      - ./data:/root/Zomboid
+      - ./workshop:/root/.local/share/Steam/steamapps/workshop
+    environment:
+      - SERVER_NAME=MyServer
+      - ADMIN_PASSWORD=change-me
+```
+
+Then connect in-game to `localhost:16261`.
+
+## Image tags
+
+| Tag | Meaning |
+|---|---|
+| `latest` | Latest published build — bleeding edge |
+| `x.y.z` (e.g. `41.78.19`) | Pinned to the Project Zomboid server semver at build time |
+
+Pin to `x.y.z` for predictable production deployments. Use `latest` for hobby servers.
+
+## Configuration
+
+The server is configured entirely via environment variables — three groups:
+
+1. **Startup options** — memory, ports, Steam toggles, presets. [Full list](https://github.com/meshi-team/project-zomboid-server/blob/main/docs/server_customization/1-server-base-variables-and-flags.md)
+2. **Server config** — multiplayer, RCON, map, PvP, player limits. [Full list](https://github.com/meshi-team/project-zomboid-server/blob/main/docs/server_customization/2-server-general-config.md)
+3. **Sandbox variables** — zombies, loot, XP, day length, car spawns. [Full list](https://github.com/meshi-team/project-zomboid-server/blob/main/docs/server_customization/3-server-sandbox-vars.md)
+
+### Most common variables
+
+```yaml
+# Server
+SERVER_NAME=MyServer
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=change-me
+SERVER_MEMORY=4096m
+PUBLIC=true
+MAX_PLAYERS=32
+
+# World
+ZOMBIES=3
+DAY_LENGTH=3
+PVP=false
+XP_MULTIPLIER=1.5
+```
+
+### Presets
+
+Apply a PZ preset via `SERVER_PRESET` (Apocalypse, Beginner, Builder, FirstWeek, Survival, Survivor, SixMonthsLater, SandboxVars). Combine with `FORCE_PRESET=1` on the first run to fully regenerate the config:
+
+```yaml
+environment:
+  - SERVER_PRESET=Survival
+  - FORCE_PRESET=1
+```
+
+## Volumes
+
+- `/root/Zomboid` — world saves, server config, logs, player DB.
+- `/root/.local/share/Steam/steamapps/workshop` — downloaded Workshop content.
+
+Bind-mount both for persistence across container recreations.
+
+## Ports
+
+| Port | Protocol | Purpose |
+|---|---|---|
+| `16261` | UDP | Main server / Steam connection |
+| `16262` | UDP | Player communication |
+| `27015` | TCP | RCON (optional, if you want external admin) |
+
+## Steam Workshop & mods
+
+Two environment variables drive Workshop integration:
+
+```yaml
+environment:
+  - WORKSHOP_ITEMS=1234567890;9876543210    # Workshop IDs to download
+  - MODS=CoolMod;MapMod                      # Mod IDs to enable (from mod.info)
+```
+
+Map-adding mods are auto-integrated: the `MAP` variable and `spawnregions.lua` are updated automatically. Clients must subscribe to the same mods to join.
+
+## Admin console
+
+```bash
+docker exec -it zomboid-server admin-console
+```
+
+Common commands: `players`, `kickuser`, `banuser`, `grantadmin`, `save`, `quit`, `help`.
+
+## Image metadata
+
+This image publishes [OCI image labels](https://github.com/opencontainers/image-spec/blob/main/annotations.md) including `org.opencontainers.image.version` (PZ semver) and `com.projectzomboid.buildId` (Steam buildid). Inspect with:
+
+```bash
+docker inspect m4lagon/project-zomboid-server:latest \
+  --format '{{json .Config.Labels}}' | jq
+```
+
+## License
+
+MIT — see [LICENSE](https://github.com/meshi-team/project-zomboid-server/blob/main/LICENSE).

--- a/zomboid-server/Dockerfile
+++ b/zomboid-server/Dockerfile
@@ -27,4 +27,28 @@ RUN chmod -R a+x /scripts \
     && /scripts/build/install-admin-console.sh \
     && /scripts/build/find_build_id.sh > /PZ_BUILD_ID
 
+ARG BUILD_DATE
+ARG VCS_REF
+ARG PZ_VERSION
+ARG PZ_BUILD_ID
+ARG DOCS=blob/main/README.md
+
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.authors="Meshi Team <https://github.com/meshi-team>"
+LABEL org.opencontainers.image.version=${PZ_VERSION}
+LABEL org.opencontainers.image.revision=${VCS_REF}
+LABEL org.opencontainers.image.title="Project Zomboid Dedicated Server"
+LABEL org.opencontainers.image.url="https://github.com/meshi-team/project-zomboid-server"
+LABEL org.opencontainers.image.documentation="https://github.com/meshi-team/project-zomboid-server/${DOCS}"
+LABEL org.opencontainers.image.source="https://github.com/meshi-team/project-zomboid-server"
+LABEL org.opencontainers.image.base.name="ghcr.io/steamcmd/steamcmd:ubuntu-22"
+LABEL org.opencontainers.image.vendor="Meshi Team"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.description="Project Zomboid dedicated server (v${PZ_VERSION}) container image with persistent world storage, workshop mod support, and customizable configuration."
+LABEL com.projectzomboid.version="${PZ_VERSION}"
+LABEL com.projectzomboid.buildId="${PZ_BUILD_ID}"
+LABEL io.github.meshi-team.project-zomboid-server.maintainer="Meshi Team"
+LABEL io.github.meshi-team.project-zomboid-server.is-production="true"
+
 ENTRYPOINT ["bash", "/scripts/entrypoint.sh"]
+CMD []

--- a/zomboid-server/scripts/entrypoint.sh
+++ b/zomboid-server/scripts/entrypoint.sh
@@ -12,7 +12,10 @@ BASE_VARIABLES_SCRIPT="${DIR}/server-base-variables.sh"
 SERVER_INIT_SCRIPT="${DIR}/init-server.sh"
 SERVER_CONFIG_UPDATE_SCRIPT="${DIR}/config/main.py"
 
-# Source server base variables
+if [[ $# -gt 0 ]]; then
+	exec "$@"
+fi
+
 if [[ -f "${BASE_VARIABLES_SCRIPT}" ]]; then
 	# shellcheck source=server-base-variables.sh
 	source "${BASE_VARIABLES_SCRIPT}"
@@ -41,11 +44,4 @@ fi
 echo "Server configuration has been updated. Continuing in 5 seconds..."
 sleep 5
 
-# Execute the server initialization script
-# If no arguments are provided, run the server as default
-if [[ $# -eq 0 ]]; then
-	exec "${SERVER_INIT_SCRIPT}"
-fi
-
-# Execute the Command passed to the container
-exec "$@"
+exec "${SERVER_INIT_SCRIPT}"


### PR DESCRIPTION
## Summary

Adds a manually-triggered release workflow that builds the Project Zomboid dedicated server image and publishes it to both GHCR and Docker Hub with semver and \`latest\` tags.

- **`.github/workflows/release-image.yml`** — \`workflow_dispatch\` workflow that:
  1. Builds a candidate image with \`BUILD_DATE\` and \`VCS_REF\` build-args.
  2. Reads the Steam buildid from the baked \`/PZ_BUILD_ID\`.
  3. Boots the server briefly (timeout 15-20 s) and greps the \`version=x.y.z\` line from its log to detect the semver.
  4. Runs a second build with \`PZ_VERSION\` and \`PZ_BUILD_ID\` as build-args so the OCI labels get set (only the LABEL layers rebuild — cache hits everything expensive).
  5. Pushes to \`ghcr.io/meshi-team/project-zomboid-server\` and \`m4lagon/project-zomboid-server\` with tags \`:<semver>\` and \`:latest\`.
  6. Syncs \`DOCKERHUB.md\` to the Docker Hub repository overview, plus a short description.
  7. Creates and force-pushes a \`v<semver>\` git tag pointing at the built SHA.
- **\`DOCKERHUB.md\`** — Docker Hub overview: quick start (\`docker run\` + compose), tag strategy, env vars, volumes, ports, Workshop/mods, admin console, image metadata.
- **\`zomboid-server/Dockerfile\`** — appends \`ARG\` + \`LABEL\` block at the end with the full OCI image spec set plus custom \`com.projectzomboid.*\` and \`io.github.meshi-team.*\` labels. Layers are at the end so rebuilds are instant when only metadata changes.
- **\`zomboid-server/scripts/entrypoint.sh\`** — short-circuits to \`exec \"\$@\"\` at the top when a command is passed, so one-shot diagnostic runs (\`docker run IMAGE cat /PZ_BUILD_ID\`) and the CI boot-probe don't pay the config pipeline / \`sleep 5\`.

## Prerequisites before the first run

- GitHub App \`meshi-team-bot\` installed on this repo (for \`Contents: write\` so the workflow can push the \`v<semver>\` tag).
- Org-level \`vars.MESHI_TEAM_BOT_APP_ID\` and \`secrets.MESHI_TEAM_BOT_PRIVATE_KEY\` reachable from this repo.
- Repo secrets \`DOCKERHUB_USERNAME\` (expected value: \`m4lagon\`) and \`DOCKERHUB_TOKEN\`.
- Docker Hub repository \`m4lagon/project-zomboid-server\` created (empty is fine).
- After the first successful push, switch the GHCR package visibility to public.